### PR TITLE
Serve NativeX stories

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,6 +2,7 @@ import GTM from '@parameter1/base-cms-marko-web-gtm/browser';
 import GAM from '@parameter1/base-cms-marko-web-gam/browser';
 import SocialSharing from '@parameter1/base-cms-marko-web-social-sharing/browser';
 import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
+import NativeX from '@parameter1/base-cms-marko-web-native-x/browser';
 import BlockLoader from './block-loader.vue';
 import MenuToggleButton from './menu-toggle-button.vue';
 import NewsletterCloseButton from './newsletter-close-button.vue';
@@ -15,6 +16,7 @@ export default (Browser) => {
   GTM(Browser);
   GAM(Browser);
   SocialSharing(Browser);
+  NativeX(Browser);
   IdentityX(Browser, {
     CustomAuthenticateComponent: IdentityXAuthenticate,
     CustomCommentStreamComponent: IdentityXCommentStream,

--- a/packages/global/components/blocks/primary-image.marko
+++ b/packages/global/components/blocks/primary-image.marko
@@ -7,7 +7,7 @@ $ const image = getAsObject(input, "obj");
 $ const hasImage = Boolean(image.src);
 
 $ const forceDisplay = defaultValue(input.forceDisplay);
-$ let display = forceDisplay || image.primaryImageDisplay;
+$ let display = forceDisplay || image.primaryImageDisplay || "center";
 $ const aspectRatio = get(image, "cropDimensions.aspectRatio");
 $ const { isLogo } = image;
 

--- a/packages/global/graphql/fragments/native-x-image.js
+++ b/packages/global/graphql/fragments/native-x-image.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+  fragment NativeXImageFragment on Image {
+    id
+    src
+    focalPoint {
+      x
+      y
+    }
+  }
+`;

--- a/packages/global/graphql/fragments/native-x-story.js
+++ b/packages/global/graphql/fragments/native-x-story.js
@@ -1,0 +1,24 @@
+const gql = require('graphql-tag');
+const imageFragment = require('./native-x-image');
+
+module.exports = gql`
+  fragment NativeXStoryFragment on Story {
+    id
+    title
+    teaser
+    body
+    publishedAt
+    url
+    primaryImage {
+      ...NativeXImageFragment
+    }
+    advertiser {
+      id
+      name
+      logo {
+        ...NativeXImageFragment
+      }
+    }
+  }
+  ${imageFragment}
+`;

--- a/packages/global/graphql/fragments/native-x-story.js
+++ b/packages/global/graphql/fragments/native-x-story.js
@@ -12,6 +12,9 @@ module.exports = gql`
     primaryImage {
       ...NativeXImageFragment
     }
+    publisher {
+      id
+    }
     advertiser {
       id
       name

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -19,7 +19,7 @@
     "@parameter1/base-cms-marko-web-gtm": "^2.13.1",
     "@parameter1/base-cms-marko-web-icons": "^2.0.0",
     "@parameter1/base-cms-marko-web-identity-x": "^2.5.0",
-    "@parameter1/base-cms-marko-web-native-x": "^2.14.0",
+    "@parameter1/base-cms-marko-web-native-x": "^2.15.0",
     "@parameter1/base-cms-marko-web-p1-events": "^2.13.1",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.4.2",
     "@parameter1/base-cms-marko-web-theme-default": "^2.7.0",

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -19,7 +19,7 @@
     "@parameter1/base-cms-marko-web-gtm": "^2.13.1",
     "@parameter1/base-cms-marko-web-icons": "^2.0.0",
     "@parameter1/base-cms-marko-web-identity-x": "^2.5.0",
-    "@parameter1/base-cms-marko-web-native-x": "^2.13.1",
+    "@parameter1/base-cms-marko-web-native-x": "^2.14.0",
     "@parameter1/base-cms-marko-web-p1-events": "^2.13.1",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.4.2",
     "@parameter1/base-cms-marko-web-theme-default": "^2.7.0",

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -1,5 +1,6 @@
 const feed = require('./feed');
 const identityX = require('./identity-x');
+const nativeX = require('./native-x');
 const printContent = require('./print-content');
 const publicFiles = require('./public-files');
 const redirects = require('./redirects');
@@ -13,6 +14,9 @@ module.exports = (app) => {
 
   // IdentityX (user routing and app context)
   identityX(app);
+
+  // NativeX (Story rendering)
+  nativeX(app);
 
   // Shared Print Content
   printContent(app);

--- a/packages/global/routes/native-x.js
+++ b/packages/global/routes/native-x.js
@@ -1,0 +1,9 @@
+const WithNativeXStory = require('@parameter1/base-cms-marko-web-native-x/middleware/with-story');
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+const template = require('../templates/content/native-x-story');
+const queryFragment = require('../graphql/fragments/native-x-story');
+
+module.exports = (app) => {
+  const config = getAsObject(app, 'locals.nativeX');
+  app.get('/sponsored/:section/:slug/:id', WithNativeXStory({ config, template, queryFragment }));
+};

--- a/packages/global/routes/native-x.js
+++ b/packages/global/routes/native-x.js
@@ -1,9 +1,9 @@
-const WithNativeXStory = require('@parameter1/base-cms-marko-web-native-x/middleware/with-story');
+const withNativeXStory = require('@parameter1/base-cms-marko-web-native-x/middleware/with-story');
 const { getAsObject } = require('@parameter1/base-cms-object-path');
 const template = require('../templates/content/native-x-story');
 const queryFragment = require('../graphql/fragments/native-x-story');
 
 module.exports = (app) => {
   const config = getAsObject(app, 'locals.nativeX');
-  app.get('/sponsored/:section/:slug/:id', WithNativeXStory({ config, template, queryFragment }));
+  app.get('/sponsored/:section/:slug/:id', withNativeXStory({ config, template, queryFragment }));
 };

--- a/packages/global/scss/components/_page-wrapper.scss
+++ b/packages/global/scss/components/_page-wrapper.scss
@@ -49,11 +49,16 @@
       margin-bottom: 40px;
     }
 
-    &--content-header {
+    &--content-header,
+    &--nativex-story-header {
       margin-bottom: 20px;
       @include media-breakpoint-up(md) {
         margin-bottom: 30px;
       }
+    }
+
+    &--nativex-story-header {
+      padding-top: 30px;
     }
 
     &--no-spacer {

--- a/packages/global/scss/components/_sponsor-logo.scss
+++ b/packages/global/scss/components/_sponsor-logo.scss
@@ -23,4 +23,9 @@
     font-size: 14px;
     font-weight: 600;
   }
+
+  &__logo {
+    max-width: 100%;
+    height: 50px;
+  }
 }

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -8,7 +8,7 @@ $ const imgSrc = get(advertiser, "logo.src");
 <if(imgSrc)>
   $ const src = buildImgixUrl(imgSrc, imgDefaults);
   $ const srcset = [`${src}&dpr=2 2x`];
-  <marko-web-block name="sponsor-logo" modifiers=["content-page"] class="mt-3">
+  <marko-web-block name="sponsor-logo">
     <marko-web-element block-name="sponsor-logo" name="label">
       Presented by
     </marko-web-element>

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -3,11 +3,11 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { advertiser } = input;
 $ const imgDefaults = { auto: "format,compress", h: 50, q: 70 };
-$ const style = { "max-width": "100%", height: 50 };
+$ const style = { "max-width": "100%", height: '50px' };
 $ const imgSrc = get(advertiser, "logo.src");
 
 <if(imgSrc)>
-  $ const src = imgSrc && buildImgixUrl(imgSrc, imgDefaults);
+  $ const src = buildImgixUrl(imgSrc, imgDefaults);
   $ const srcset = [`${src}&dpr=2 2x`];
   <marko-web-block name="sponsor-logo" modifiers=["content-page"] class="mt-3">
     <marko-web-element block-name="sponsor-logo" name="label">

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -2,8 +2,8 @@ import { buildImgixUrl } from "@parameter1/base-cms-image";
 import { get } from "@parameter1/base-cms-object-path";
 
 $ const { advertiser } = input;
-$ const imgDefaults = { auto: 'format,compress', h: 50, q: 70 };
-$ const style = { 'max-width': '100%', height: 50 };
+$ const imgDefaults = { auto: "format,compress", h: 50, q: 70 };
+$ const style = { "max-width": "100%", height: 50 };
 $ const imgSrc = get(advertiser, "logo.src");
 
 <if(imgSrc)>

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -3,7 +3,6 @@ import { get } from "@parameter1/base-cms-object-path";
 
 $ const { advertiser } = input;
 $ const imgDefaults = { auto: "format,compress", h: 50, q: 70 };
-$ const style = { "max-width": "100%", height: '50px' };
 $ const imgSrc = get(advertiser, "logo.src");
 
 <if(imgSrc)>
@@ -18,7 +17,6 @@ $ const imgSrc = get(advertiser, "logo.src");
       src=src
       srcset=srcset
       alt="Sponsor Logo"
-      attrs={ style }
     />
   </marko-web-block>
 </if>

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -1,0 +1,25 @@
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { advertiser } = input;
+$ const imgDefaults = { auto: 'format,compress', h: 50, q: 70 };
+$ const style = { 'max-width': '100%', height: 50 };
+
+$ const imgSrc = get(advertiser, "logo.src");
+$ const imgSrc1x = imgSrc && buildImgixUrl(imgSrc, imgDefaults);
+$ const imgSrc2x = imgSrc && buildImgixUrl(imgSrc, { ...imgDefaults, dpr: 2 });
+
+<if(imgSrc)>
+  <marko-web-block name="sponsor-logo" modifiers=["content-page"] class="mt-3">
+    <marko-web-element block-name="sponsor-logo" name="label">
+      Presented by
+    </marko-web-element>
+    <marko-web-img
+      class="sponsor-logo__logo"
+      src=imgSrc1x
+      srcset=[`${imgSrc2x} 2x`]
+      alt="Sponsor Logo"
+      attrs={ style }
+    />
+  </marko-web-block>
+</if>

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -4,20 +4,19 @@ import { get } from "@parameter1/base-cms-object-path";
 $ const { advertiser } = input;
 $ const imgDefaults = { auto: 'format,compress', h: 50, q: 70 };
 $ const style = { 'max-width': '100%', height: 50 };
-
 $ const imgSrc = get(advertiser, "logo.src");
-$ const imgSrc1x = imgSrc && buildImgixUrl(imgSrc, imgDefaults);
-$ const imgSrc2x = imgSrc && buildImgixUrl(imgSrc, { ...imgDefaults, dpr: 2 });
 
 <if(imgSrc)>
+  $ const src = imgSrc && buildImgixUrl(imgSrc, imgDefaults);
+  $ const srcset = [`${src}&dpr=2 2x`];
   <marko-web-block name="sponsor-logo" modifiers=["content-page"] class="mt-3">
     <marko-web-element block-name="sponsor-logo" name="label">
       Presented by
     </marko-web-element>
     <marko-web-img
       class="sponsor-logo__logo"
-      src=imgSrc1x
-      srcset=[`${imgSrc2x} 2x`]
+      src=src
+      srcset=srcset
       alt="Sponsor Logo"
       attrs={ style }
     />

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -7,19 +7,17 @@ $ const { primarySection } = content;
 
 <global-default-page title=story.title description=story.teaser>
   <@head>
-    <!-- <marko-web-gtm-content-context|{ context }| id=id>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      <marko-web-p1-events-track-content node=content />
-    </marko-web-resolve-page> -->
-    <script>console.log('include gtm/trakcing');</script>
+    <marko-web-native-x-gtm-init />
   </@head>
   <@page>
+    <marko-web-native-x-story-track-page-view story=story />
+    <marko-web-native-x-story-track-social-share story=story />
+
     <marko-web-page-wrapper>
       <@section modifiers=["first-sm"]>
         <span class="d-none"></span>
       </@section>
+
       <@section|{ blockName }| modifiers=["content-header"]>
         <div class="content-page-header">
           <default-theme-breadcrumbs modifiers=["content-page"]>
@@ -33,7 +31,7 @@ $ const { primarySection } = content;
       </@section>
 
       <@section>
-        <div class="content-page-body">
+        <div class="content-page-body" id="native-x-story-body">
           <default-theme-page-contents|{ blockName }|>
             <global-primary-image-block obj=content.primaryImage />
             <marko-web-content-body block-name=blockName obj=content />
@@ -44,7 +42,9 @@ $ const { primarySection } = content;
           </default-theme-page-contents>
         </div>
       </@section>
-
     </marko-web-page-wrapper>
+
+    <marko-web-native-x-story-track-outbound-links story=story container="#native-x-story-body" />
+    <marko-web-native-x-story-track-end-of-content story=story />
   </@page>
 </global-default-page>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -5,7 +5,7 @@ $ const content = convert(story);
 $ const { id, type } = content;
 $ const { primarySection } = content;
 
-<global-content-page id=id type=type>
+<global-default-page title=story.title description=story.teaser>
   <@head>
     <!-- <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
@@ -47,4 +47,4 @@ $ const { primarySection } = content;
 
     </marko-web-page-wrapper>
   </@page>
-</global-content-page>
+</global-default-page>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -10,8 +10,9 @@ $ const { primarySection } = content;
     <marko-web-native-x-gtm-init />
   </@head>
   <@page>
-    <marko-web-native-x-story-track-page-view story=story />
-    <marko-web-native-x-story-track-social-share story=story />
+    <marko-web-native-x-story-track-init story=story />
+    <marko-web-native-x-story-track-page-view />
+    <marko-web-native-x-story-track-social-share />
 
     <marko-web-page-wrapper>
       <@section modifiers=["first-sm"]>
@@ -44,7 +45,7 @@ $ const { primarySection } = content;
       </@section>
     </marko-web-page-wrapper>
 
-    <marko-web-native-x-story-track-outbound-links story=story container="#native-x-story-body" />
-    <marko-web-native-x-story-track-end-of-content story=story />
+    <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" />
+    <marko-web-native-x-story-track-end-of-content />
   </@page>
 </global-default-page>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -1,0 +1,50 @@
+import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story-to-content";
+
+$ const { story } = input;
+$ const content = convert(story);
+$ const { id, type } = content;
+$ const { primarySection } = content;
+
+<global-content-page id=id type=type>
+  <@head>
+    <!-- <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-p1-events-track-content node=content />
+    </marko-web-resolve-page> -->
+    <script>console.log('include gtm/trakcing');</script>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section modifiers=["first-sm"]>
+        <span class="d-none"></span>
+      </@section>
+      <@section|{ blockName }| modifiers=["content-header"]>
+        <div class="content-page-header">
+          <default-theme-breadcrumbs modifiers=["content-page"]>
+            <@item>
+              ${primarySection.name}
+            </@item>
+          </default-theme-breadcrumbs>
+          <marko-web-content-name tag="h1" block-name=blockName obj=content />
+          <presented-by advertiser=story.advertiser />
+        </div>
+      </@section>
+
+      <@section>
+        <div class="content-page-body">
+          <default-theme-page-contents|{ blockName }|>
+            <global-primary-image-block obj=content.primaryImage />
+            <marko-web-content-body block-name=blockName obj=content />
+            <marko-web-social-sharing
+              path=content.siteContext.path
+              providers=["facebook", "linkedin", "twitter", "pinterest"]
+            />
+          </default-theme-page-contents>
+        </div>
+      </@section>
+
+    </marko-web-page-wrapper>
+  </@page>
+</global-content-page>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -15,11 +15,7 @@ $ const { primarySection } = content;
     <marko-web-native-x-story-track-social-share />
 
     <marko-web-page-wrapper>
-      <@section modifiers=["first-sm"]>
-        <span class="d-none"></span>
-      </@section>
-
-      <@section|{ blockName }| modifiers=["content-header"]>
+      <@section|{ blockName }| modifiers=["nativex-story-header"]>
         <div class="content-page-header">
           <default-theme-breadcrumbs modifiers=["content-page"]>
             <@item>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,21 +2088,6 @@
     moment "^2.29.1"
     node-fetch "^2.6.1"
 
-"@parameter1/base-cms-marko-web-native-x@^2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-native-x/-/base-cms-marko-web-native-x-2.14.0.tgz#9521476b1dd0975432ea826eccc90aa79679b8b2"
-  integrity sha512-3CKXk64ltkatLMn8XVjOTH9A6b2Qvg3NZNmwTKtLrOGYU5xCB3OXf5Hk3goPAARmF58GJvWY6uW9gbpq20E/yw==
-  dependencies:
-    "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.13.0"
-    "@parameter1/base-cms-object-path" "^2.5.0"
-    "@parameter1/base-cms-utils" "^2.4.2"
-    "@parameter1/base-cms-web-common" "^2.5.0"
-    apollo-cache-inmemory "^1.6.6"
-    apollo-client "^2.6.10"
-    apollo-link-http "^1.5.17"
-    graphql-tag "^2.11.0"
-    node-fetch "^2.6.1"
-
 "@parameter1/base-cms-marko-web-native-x@^2.15.0":
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-native-x/-/base-cms-marko-web-native-x-2.15.0.tgz#a5e66dcbf5f2bc14dabed396371aacbce61ff4ad"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,6 +2103,22 @@
     graphql-tag "^2.11.0"
     node-fetch "^2.6.1"
 
+"@parameter1/base-cms-marko-web-native-x@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-native-x/-/base-cms-marko-web-native-x-2.15.0.tgz#a5e66dcbf5f2bc14dabed396371aacbce61ff4ad"
+  integrity sha512-/uAQVxAb14WvopWT9rSD8G+hjc5MfKPW1Q1Gj/FBs7CgQOsoXCzRl2dU4OCJ8koRYitHgkx8H9eZyFH/4j/BEA==
+  dependencies:
+    "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.13.0"
+    "@parameter1/base-cms-marko-web-gtm" "^2.13.1"
+    "@parameter1/base-cms-object-path" "^2.5.0"
+    "@parameter1/base-cms-utils" "^2.4.2"
+    "@parameter1/base-cms-web-common" "^2.5.0"
+    apollo-cache-inmemory "^1.6.6"
+    apollo-client "^2.6.10"
+    apollo-link-http "^1.5.17"
+    graphql-tag "^2.11.0"
+    node-fetch "^2.6.1"
+
 "@parameter1/base-cms-marko-web-p1-events@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-p1-events/-/base-cms-marko-web-p1-events-2.13.1.tgz#804d22fc51c10789c2e9dceae99aaac09946ab82"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,14 +2088,19 @@
     moment "^2.29.1"
     node-fetch "^2.6.1"
 
-"@parameter1/base-cms-marko-web-native-x@^2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-native-x/-/base-cms-marko-web-native-x-2.13.1.tgz#2997dab034984101670c734e46f8f7ee5ee3f292"
-  integrity sha512-SfSCrhgGyBUApsNhj6I+5jLgajT1qP6DrM8P5eJbbNZeoUljt4yLUf9quC9WLByMQw+1ieHTU3QoGjpMDW3YAw==
+"@parameter1/base-cms-marko-web-native-x@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-native-x/-/base-cms-marko-web-native-x-2.14.0.tgz#9521476b1dd0975432ea826eccc90aa79679b8b2"
+  integrity sha512-3CKXk64ltkatLMn8XVjOTH9A6b2Qvg3NZNmwTKtLrOGYU5xCB3OXf5Hk3goPAARmF58GJvWY6uW9gbpq20E/yw==
   dependencies:
     "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.13.0"
     "@parameter1/base-cms-object-path" "^2.5.0"
     "@parameter1/base-cms-utils" "^2.4.2"
+    "@parameter1/base-cms-web-common" "^2.5.0"
+    apollo-cache-inmemory "^1.6.6"
+    apollo-client "^2.6.10"
+    apollo-link-http "^1.5.17"
+    graphql-tag "^2.11.0"
     node-fetch "^2.6.1"
 
 "@parameter1/base-cms-marko-web-p1-events@^2.13.1":


### PR DESCRIPTION
Utilizes new middleware from parameter1/base-cms#60 to retrieve a story and render it on the site.

- [x] Render NativeX story following content layout
- [x] Requires update to native-x package for parameter1/base-cms#62

![screencapture-localhost-9804-sponsored-driving-tests-insights-into-trucking-and-transportation-companies-show-hiring-difficulties-and-issues-keeping-drivers-employed-604a5ac81b33df0001a464b9-2021-03-31-11_13_35](https://user-images.githubusercontent.com/1778222/113176603-49ca6680-9212-11eb-80ca-c2866ff7e87b.png)
