### PR TITLE
Only show author bios at the end of content bodies

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -29,37 +29,22 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     <global-gam-wallpaper-ad aliases=aliases position="content_page" />
   </@section>
 
-  <@section|{ blockName, content, aliases, authors}| modifiers=["content-header"]>
+  <@section|{ blockName, content, aliases, authors }| modifiers=["content-header"]>
     $ const { primarySection } = content;
     <div class="content-page-header">
       <global-content-page-breadcrumbs section=primarySection />
       <marko-web-content-name tag="h1" block-name=blockName obj=content />
-
-      $ const contentContactLength = ["authors", "contributors", "photographers"].reduce((num, field) => {
-        const contacts = getAsArray(content, `${field}.edges`);
-        return num + contacts.length;
-      }, 0);
       <if(type !== "contact")>
-        <if(authors.length === 1 && contentContactLength < 2)>
+        <if(authors.length === 1)>
           <global-author-published-node author=authors[0] content=content />
         </if>
-        <else>
+        <else-if(authors.length > 1)>
           <default-theme-content-attribution obj=content elements=["authors"] />
-        </else>
+        </else-if>
       </if>
-
-      <if(authors.length !== 1 || contentContactLength > 1)>
+      <if(displayPublishedDate && authors.length !== 1)>
         <default-theme-page-dates|{ blockName }|>
-          <if(type === "event")>
-            <marko-web-content-starts block-name=blockName obj=content />
-            <marko-web-content-ends block-name=blockName obj=content />
-          </if>
-          <else-if(type === "webinar")>
-            <marko-web-content-starts block-name=blockName obj=content />
-          </else-if>
-          <else-if(displayPublishedDate)>
-            <global-content-published-node block-name=blockName obj=content />
-          </else-if>
+          <global-content-published-node block-name=blockName obj=content />
         </default-theme-page-dates>
       </if>
       <global-sponsored-section-logo alias=primarySection.alias modifiers=["content-page"] class="mt-3" />
@@ -133,16 +118,9 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           </default-theme-content-download>
         </if>
         <if(type !== "contact")>
-          <if(authors.length)>
-            <for|author| of=authors>
-              <if(author.name && !author.name.includes('Staff'))>
-                <global-author-published-node author=author content=content showPublished=false />
-                <if(author.body)>
-                  <p>$!{author.body}</p>
-                </if>
-              </if>
-            </for>
-          </if>
+          <for|author| of=authors>
+            <marko-web-content-body obj=author block-name="inline-author-bio" />
+          </for>
         </if>
 
         <if(displayNewsletterSignup)>

--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -103,16 +103,6 @@ fragment ContentPageFragment on Content {
       label
     }
   }
-  ... on ContentTop100 {
-    rank
-    phone
-    website
-    previousRank
-    founded
-    revenueCurrent
-    companyExecutives
-    marketsServing
-  }
   ... on Media {
     fileSrc
   }
@@ -135,26 +125,6 @@ fragment ContentPageFragment on Content {
             src(input: { options: { auto: "format,compress", q: 70 } })
             alt
           }
-        }
-      }
-    }
-    contributors {
-      edges {
-        node {
-          id
-          name
-          type
-          canonicalPath
-        }
-      }
-    }
-    photographers {
-      edges {
-        node {
-          id
-          name
-          type
-          canonicalPath
         }
       }
     }

--- a/packages/global/scss/components/_author-published-node.scss
+++ b/packages/global/scss/components/_author-published-node.scss
@@ -23,7 +23,21 @@
     text-transform: none;
   }
 
-  &__content-updated::before {
-    content: " | ";
+  &__content-updated {
+    &::before {
+      content: " | ";
+    }
+  }
+}
+
+.inline-author-bio {
+  &__content-body {
+    margin-bottom: 18px;
+    font-size: 16px;
+    font-style: italic;
+
+    @include media-breakpoint-up(md) {
+      font-size: 18px;
+    }
   }
 }


### PR DESCRIPTION
Also removes “strange” author/contact display logic, since contributors and photographers are never displayed. Also removes webinar and event logic since these content types are currently unused. This can be revisited if/when those content types are brought into use.

This fixes a the "floating headshot" problem where an author missing a bio simply had an image and a name.
It also resolves spacing between the bio section and the newsletter signup form.

New:
![image](https://user-images.githubusercontent.com/3289485/123816922-561b9980-d8bd-11eb-9d3b-8134bdea5333.png)

Old "headshot" and spacing problem:
![image](https://user-images.githubusercontent.com/3289485/123817156-85caa180-d8bd-11eb-9c0c-4f64a1ca10f0.png)

