### PR TITLE
Newsletter sign-up form adjustments

### DIFF
--- a/packages/global/browser/inline-newsletter-form.vue
+++ b/packages/global/browser/inline-newsletter-form.vue
@@ -15,6 +15,7 @@
     />
     <step-2
       v-if="step === 2"
+      :site-name="siteName"
       :email="email"
       :default-newsletter-name="defaultNewsletter.name"
       :newsletters="newsletters"
@@ -40,6 +41,10 @@ export default {
   },
 
   props: {
+    siteName: {
+      type: String,
+      required: true,
+    },
     recaptchaSiteKey: {
       type: String,
       required: true,

--- a/packages/global/browser/inline-newsletter-form/step1.vue
+++ b/packages/global/browser/inline-newsletter-form/step1.vue
@@ -33,6 +33,8 @@
           :is-loading="isLoading"
         />
       </form>
+      <privacy-policy :block-name="blockName" />
+
 
       <div v-if="error" class="alert alert-danger mt-3 mb-0" role="alert">
         <strong>An error ocurred.</strong>
@@ -44,12 +46,14 @@
 
 
 <script>
+import PrivacyPolicy from '../newsletter-signup-form/privacy-policy.vue';
 import SignUpButton from '../newsletter-signup-form/sign-up-button.vue';
 
 import getRecaptchaToken from '../newsletter-signup-form/get-recaptcha-token';
 
 export default {
   components: {
+    PrivacyPolicy,
     SignUpButton,
   },
 

--- a/packages/global/browser/newsletter-signup-form/privacy-policy.vue
+++ b/packages/global/browser/newsletter-signup-form/privacy-policy.vue
@@ -2,7 +2,7 @@
   <div :class="`${blockName}__privacy-policy`">
     By providing your email, you agree to our
     <a href="/termsandprivacy" target="_blank" rel="noopener">
-      Terms &amp; Conditions and Privacy Policy</a>.
+      Terms of Use and Privacy Policy</a>.
     This site is protected by reCAPTCHA and the Google
     <a href="https://policies.google.com/privacy">Privacy Policy</a> and
     <a href="https://policies.google.com/terms">Terms of Service</a> apply.

--- a/packages/global/browser/newsletter-signup-form/sign-up-button.vue
+++ b/packages/global/browser/newsletter-signup-form/sign-up-button.vue
@@ -2,7 +2,7 @@
   <button
     class="text-nowrap"
     type="submit"
-    :disabled="isLoading"
+    :disabled="isLoading || disabled"
   >
     <div class="d-flex align-items-center">
       <div
@@ -28,6 +28,10 @@ export default {
     label: {
       type: String,
       default: 'Sign Up',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
   },
 };

--- a/packages/global/browser/newsletter-signup-form/step2.vue
+++ b/packages/global/browser/newsletter-signup-form/step2.vue
@@ -126,6 +126,10 @@ export default {
   },
 
   props: {
+    siteName: {
+      type: String,
+      required: true,
+    },
     recaptchaSiteKey: {
       type: String,
       required: true,

--- a/packages/global/browser/newsletter-signup-form/step2.vue
+++ b/packages/global/browser/newsletter-signup-form/step2.vue
@@ -8,93 +8,110 @@
       :class="`${blockName}__card-body`"
       @submit.prevent="submit"
     >
-      <div :class="`${blockName}__header`">
-        Complete your sign-up
-      </div>
-      <div :class="`${blockName}__about-you`">
-        About you
-      </div>
-      <div :class="`${blockName}__form`">
-        <input-form-group
-          v-model="companyName"
-          :block-name="blockName"
-          :disabled="isLoading"
-          field="company-name"
-          label="Company Name"
-          required
-          @focus="didFocus = true"
-        />
-
-        <select-form-group
-          v-model="demographicValue"
-          :block-name="blockName"
-          :disabled="isLoading"
-          field="primary-role"
-          :label="demographic.label"
-          required
-          @focus="didFocus = true"
-        >
-          <option value="">
-            Select
-          </option>
-          <option
-            v-for="value in demographic.values"
-            :key="value.id"
-            :value="value.id"
-          >
-            {{ value.label }}
-          </option>
-        </select-form-group>
-
-        <input-form-group
-          v-model="postalCode"
-          :block-name="blockName"
-          :disabled="isLoading"
-          field="postal-code"
-          label="Zip/Postal"
-          required
-          @focus="didFocus = true"
-        />
-      </div>
-
-      <div v-if="newsletters.length">
-        <div :class="`${blockName}__subscriptions-header`">
-          Choose your subscriptions
-        </div>
-
-        <div :class="`${blockName}__subscriptions row`">
-          <div
-            v-for="newsletter in newsletters"
-            :key="newsletter.deploymentTypeId"
-            class="col-12 col-md-6"
-          >
-            <newsletter-checkbox
-              :deployment-type-id="newsletter.deploymentTypeId"
-              :name="newsletter.name"
-              :description="newsletter.description"
+      <transition
+        :leave-active-class="`${blockName}__slide-out`"
+        @after-leave="formHidden = true"
+      >
+        <div v-show="!isComplete">
+          <div :class="`${blockName}__header`">
+            Complete your sign-up
+          </div>
+          <div :class="`${blockName}__about-you`">
+            About you
+          </div>
+          <div :class="`${blockName}__form`">
+            <input-form-group
+              v-model="companyName"
+              :block-name="blockName"
               :disabled="isLoading"
-              :in-pushdown="inPushdown"
-              @change="selectNewsletter"
+              field="company-name"
+              label="Company Name"
+              required
+              @focus="didFocus = true"
+            />
+
+            <select-form-group
+              v-model="demographicValue"
+              :block-name="blockName"
+              :disabled="isLoading"
+              field="primary-role"
+              :label="demographic.label"
+              required
+              @focus="didFocus = true"
+            >
+              <option value="">
+                Select
+              </option>
+              <option
+                v-for="value in demographic.values"
+                :key="value.id"
+                :value="value.id"
+              >
+                {{ value.label }}
+              </option>
+            </select-form-group>
+
+            <input-form-group
+              v-model="postalCode"
+              :block-name="blockName"
+              :disabled="isLoading"
+              field="postal-code"
+              label="Zip/Postal"
+              required
               @focus="didFocus = true"
             />
           </div>
-        </div>
-      </div>
 
-      <div v-if="!isComplete" :class="`${blockName}__signup`">
-        <div>
-          <sign-up-button :class="`${blockName}__form-button`" :is-loading="isLoading" />
+          <div v-if="newsletters.length">
+            <div :class="`${blockName}__subscriptions-header`">
+              Choose your subscriptions
+            </div>
+
+            <div :class="`${blockName}__subscriptions row`">
+              <div
+                v-for="newsletter in newsletters"
+                :key="newsletter.deploymentTypeId"
+                class="col-12 col-md-6"
+              >
+                <newsletter-checkbox
+                  :deployment-type-id="newsletter.deploymentTypeId"
+                  :name="newsletter.name"
+                  :description="newsletter.description"
+                  :disabled="isLoading"
+                  :in-pushdown="inPushdown"
+                  @change="selectNewsletter"
+                  @focus="didFocus = true"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div :class="`${blockName}__signup`">
+            <div>
+              <sign-up-button
+                :class="`${blockName}__form-button`"
+                :is-loading="isLoading"
+                :disabled="isComplete"
+              />
+            </div>
+            <privacy-policy :block-name="blockName" />
+          </div>
         </div>
-        <privacy-policy :block-name="blockName" />
-      </div>
-      <div v-else>
-        <div :class="`${blockName}__header`">
-          Thank you!
+      </transition>
+
+      <transition
+        :enter-active-class="`${blockName}__slide-in`"
+      >
+        <div v-show="formHidden">
+          <div :class="`${blockName}__thank-you-header`">
+            Thank you for subscribing!
+          </div>
+          <p class="mb-0">
+            You should start receiving your subscription in the next 24 hours
+            along with a special welcome from the experts at <em>{{ siteName }}</em>.
+          </p>
         </div>
-        <p class="mb-0">
-          Your submission has been received.
-        </p>
-      </div>
+      </transition>
 
       <div v-if="error" class="alert alert-danger mt-3 mb-0" role="alert">
         <strong>An error ocurred.</strong>
@@ -165,6 +182,7 @@ export default {
     blockName: 'complete-newsletter-signup',
     didFocus: false,
     error: null,
+    formHidden: false,
     isComplete: false,
     isLoading: false,
 

--- a/packages/global/browser/site-newsletter-menu.vue
+++ b/packages/global/browser/site-newsletter-menu.vue
@@ -16,6 +16,7 @@
       />
       <step-2
         v-if="step === 2"
+        :site-name="siteName"
         :email="email"
         :default-newsletter-name="defaultNewsletter.name"
         :newsletters="newsletters"
@@ -43,6 +44,10 @@ export default {
   },
 
   props: {
+    siteName: {
+      type: String,
+      required: true,
+    },
     recaptchaSiteKey: {
       type: String,
       required: true,

--- a/packages/global/components/blocks/newsletter-signup-banner.marko
+++ b/packages/global/components/blocks/newsletter-signup-banner.marko
@@ -11,7 +11,7 @@ $ const {
   defaultNewsletter,
   newsletters,
   demographic,
-} = site.getAsObject('newsletter.signupBanner');
+} = site.getAsObject("newsletter.signupBanner");
 
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/files/base/randallreilly/all/image/${imagePath}`, { w: 120, auto: "format,compress&q=70" }) : null;
 $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
@@ -20,6 +20,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
   <marko-web-browser-component
     name="GlobalInlineNewsletterForm"
     props={
+      siteName: config.website("name"),
       name,
       description,
       defaultNewsletter,

--- a/packages/global/components/site-newsletter-menu.marko
+++ b/packages/global/components/site-newsletter-menu.marko
@@ -23,6 +23,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
     name="GlobalSiteNewsletterMenu"
     ssr=true
     props={
+      siteName: config.website("name"),
       name,
       description,
       defaultNewsletter,

--- a/packages/global/scss/components/_site-newsletter-menu.scss
+++ b/packages/global/scss/components/_site-newsletter-menu.scss
@@ -380,4 +380,17 @@
     margin-left: 10px;
     @include skin-button("inline-newsletter-signup");
   }
+
+  &__privacy-policy {
+    margin-top: 12px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.28;
+    color: $gray-100;
+
+    a {
+      color: $gray-100;
+      text-decoration: underline;
+    }
+  }
 }

--- a/packages/global/scss/components/_site-newsletter-menu.scss
+++ b/packages/global/scss/components/_site-newsletter-menu.scss
@@ -1,3 +1,29 @@
+@keyframes slideOutUpAndFade {
+  from {
+    max-height: 1000px;
+    opacity: 1;
+  }
+
+  to {
+    max-height: 0;
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes slideInDownAndFade {
+  from {
+    max-height: 0;
+    visibility: hidden;
+    opacity: 0;
+  }
+
+  to {
+    max-height: 300px;
+    opacity: 1;
+  }
+}
+
 .grecaptcha-badge {
   visibility: hidden;
 }
@@ -124,6 +150,18 @@
 .complete-newsletter-signup {
   $self: &;
 
+  &__slide-out {
+    animation-name: slideOutUpAndFade;
+    animation-duration: 500ms;
+    animation-fill-mode: both;
+  }
+
+  &__slide-in {
+    animation-name: slideInDownAndFade;
+    animation-duration: 500ms;
+    animation-fill-mode: both;
+  }
+
   &__card-header {
     display: inline-flex;
     align-items: center;
@@ -142,6 +180,7 @@
 
   &__card-body {
     max-width: 652px;
+    overflow: hidden;
   }
 
   &__check-icon {
@@ -163,6 +202,13 @@
     @include media-breakpoint-up(md) {
       margin-bottom: 24px;
     }
+  }
+
+  &__thank-you-header {
+    margin-bottom: 12px;
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1.14;
   }
 
   &__about-you {

--- a/packages/global/scss/components/_site-newsletter-menu.scss
+++ b/packages/global/scss/components/_site-newsletter-menu.scss
@@ -428,6 +428,7 @@
   }
 
   &__privacy-policy {
+    max-width: 525px;
     margin-top: 12px;
     font-size: 12px;
     font-weight: 400;

--- a/packages/global/scss/components/_site-newsletter-menu.scss
+++ b/packages/global/scss/components/_site-newsletter-menu.scss
@@ -373,14 +373,14 @@
     display: none;
     @include media-breakpoint-up(md) {
       display: block;
-      width: 120px;
+      width: 100px;
       margin-top: auto;
       margin-right: 20px;
-      margin-bottom: -22px;
+      margin-bottom: auto;
     }
 
     img {
-      width: 120px;
+      width: 100px;
     }
   }
 

--- a/packages/global/scss/components/_site-newsletter-menu.scss
+++ b/packages/global/scss/components/_site-newsletter-menu.scss
@@ -73,7 +73,6 @@
 
   &__privacy-policy {
     @include skin-typography($style: "credit-disclaimer");
-    max-width: 220px;
     margin-top: 10px;
     margin-bottom: 14px;
 
@@ -253,15 +252,11 @@
   }
 
   &__privacy-policy {
-    max-width: 250px;
+    @include skin-typography($style: "credit-disclaimer");
     margin-bottom: 15px;
-    font-size: 15px;
-    font-weight: 400;
-    line-height: 1.33;
 
     @include media-breakpoint-up(md) {
       max-width: 100%;
-      padding-right: 90px;
       margin-bottom: 0;
       margin-left: 17px;
     }

--- a/sites/ccjdigital.com/config/newsletter.js
+++ b/sites/ccjdigital.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every trucking professional needs to know.',
-  imagePath: 'static/newsletter-pushdown/ccj-half.png',
   defaultNewsletter: {
     deploymentTypeId: 29,
     name: 'CCJ Daily Report',
@@ -52,9 +51,11 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/ccj-full.png',
   },
   pushdown: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/ccj-half.png',
     description: 'Join 80,000 trucking professionals who get helpful insights and important news delivered straight to their inbox with the CCJ newsletter.',
   },
 

--- a/sites/equipmentworld.com/config/newsletter.js
+++ b/sites/equipmentworld.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every contractor needs to know in the <span class="newsletter-name">Equipment World</span> newsletter.',
-  imagePath: 'static/newsletter-pushdown/eqw-half.png',
   defaultNewsletter: {
     deploymentTypeId: 22,
     name: 'Equipment World Daily',
@@ -61,10 +60,12 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/eqw-full.png',
   },
   pushdown: {
     ...defaults,
     description: 'Join 55,000 construction professionals who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Equipment World</span> newsletter.',
+    imagePath: 'static/newsletter-pushdown/eqw-half.png',
   },
 
   // links off to seperate omeda dragonform

--- a/sites/hardworkingtrucks.com/config/newsletter.js
+++ b/sites/hardworkingtrucks.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every truck owner needs to know in the <em>Hard Working Trucks</em> newsletter.',
-  imagePath: 'static/newsletter-pushdown/hwt-half.png',
   defaultNewsletter: {
     deploymentTypeId: 24,
     name: 'Hard Working Trucks Weekly',
@@ -35,11 +34,13 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/hwt-full.png',
   },
   pushdown: {
     ...defaults,
     name: 'Newsletter Just for Truck Owners',
     description: 'Get news you need to know about pickups, commercial vans and Class 3-8 trucks — delivered straight to your inbox.',
+    imagePath: 'static/newsletter-pushdown/hwt-half.png',
   },
 
   // links off to seperate omeda dragonform

--- a/sites/overdriveonline.com/config/newsletter.js
+++ b/sites/overdriveonline.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every owner-operator needs to know in the <span class="newsletter-name">Overdrive</span> newsletter.',
-  imagePath: 'static/iphone-x-mockup-noshadow-2x.png',
   defaultNewsletter: {
     deploymentTypeId: 33,
     name: 'Overdrive Daily Newsletter',
@@ -48,10 +47,12 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/ovd-full.png',
   },
   pushdown: {
     ...defaults,
     description: 'Join 135,000 owner-operators who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Overdrive</span> newsletter.',
+    imagePath: 'static/newsletter-pushdown/ovd-half.png',
   },
 
   // links off to seperate omeda dragonform

--- a/sites/totallandscapecare.com/config/newsletter.js
+++ b/sites/totallandscapecare.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every landscaping professional needs to know in the <em>TLC</em> newsletter.',
-  imagePath: 'static/newsletter-pushdown/tlc-half.png',
   defaultNewsletter: {
     deploymentTypeId: 17,
     name: 'Total Landscape Care Daily',
@@ -41,10 +40,12 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/tlc-full.png',
   },
   pushdown: {
     ...defaults,
     description: 'Join 14,000 landscaping professionals who get helpful insights and important news delivered straight to their inbox with the <em>Total Landscape Care</em> newsletter.',
+    imagePath: 'static/newsletter-pushdown/tlc-half.png',
   },
 
   // links off to seperate omeda dragonform

--- a/sites/truckersnews.com/config/newsletter.js
+++ b/sites/truckersnews.com/config/newsletter.js
@@ -9,7 +9,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the job alerts, industry insights and trending news every truck driver needs to know in the <em>Truckers News</em> newsletter.',
-  imagePath: 'static/newsletter-pushdown/tn-half.png',
   defaultNewsletter: {
     deploymentTypeId: 27,
     name: 'Truckers News Daily',
@@ -49,10 +48,12 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/tn-full.png',
   },
   pushdown: {
     ...defaults,
     description: 'Join 40,000 company drivers who get helpful insights and important news delivered straight to their inbox with the <em>Truckers News</em> newsletter.',
+    imagePath: 'static/newsletter-pushdown/tn-half.png',
   },
 
   // links off to seperate omeda dragonform

--- a/sites/truckpartsandservice.com/config/newsletter.js
+++ b/sites/truckpartsandservice.com/config/newsletter.js
@@ -8,7 +8,6 @@ const baseConfig = {
 const defaults = {
   name: 'Don’t Miss Out',
   description: 'Get the business tips, industry insights and trending news every dealer and distributor needs to know in the <em>TPS</em> newsletter.',
-  imagePath: 'static/newsletter-pushdown/tps-half.png',
   defaultNewsletter: {
     deploymentTypeId: 13,
     name: 'Trucks Parts Service Daily',
@@ -45,10 +44,12 @@ module.exports = {
   // uses inline omeda form
   signupBanner: {
     ...defaults,
+    imagePath: 'static/newsletter-pushdown/tps-full.png',
   },
   pushdown: {
     ...defaults,
     description: 'Join 20,000 dealer and aftermarket professionals who get helpful insights and important news delivered straight to their inbox with the <em>Trucks, Parts, Service</em> newsletter.',
+    imagePath: 'static/newsletter-pushdown/tps-half.png',
   },
 
   // links off to seperate omeda dragonform


### PR DESCRIPTION
- remove `max-width` properties from privacy policy containers
- add privacy policy (and recaptcha) language to step one of the inline form
- adjust step two thank you message to read "Thank you for subscribing" with a body of `You should start receiving your subscription in the next 24 hours along with a special welcome from the experts at <em>{{ siteName }}</em>`
- use full-size newsletter "phone images" on inline form (due to increased size of the privacy language)
- change `Terms & Conditions` to `Terms of Use` in privacy language

![image](https://user-images.githubusercontent.com/3289485/123858659-66496e00-d8e9-11eb-86a5-f5ffcaab2ffa.png)
