### PR TITLE
Convert CCJ top 250 landing and guide pages to use website-section page type and context base off root ccj-top-250 section

### DIFF
--- a/sites/ccjdigital.com/server/routes/top250.js
+++ b/sites/ccjdigital.com/server/routes/top250.js
@@ -8,9 +8,11 @@ module.exports = (app) => {
   const { rootAlias = 'ccj-top-250' } = config;
   app.get(`/:alias(${rootAlias})`, withWebsiteSection({ template, queryFragment }));
 
-  Object.keys(config.guides).forEach((alias) => {
-    app.get(`/${rootAlias}/${alias}`, (_, res) => {
-      res.marko(guide, { alias });
-    });
+  Object.keys(config.guides).forEach((guideAlias) => {
+    app.get(`/:alias(${rootAlias})/${guideAlias}`, withWebsiteSection({
+      template: guide,
+      queryFragment,
+      redirectOnPathMismatch: false,
+    }));
   });
 };

--- a/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
+++ b/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
@@ -17,10 +17,11 @@ $ const guide = get(top250, `guides.${guideAlias}`);
     page-node=pageNode
   >
     <@head>
-      <marko-web-gtm-default-context|{ context }|>
+      <marko-web-gtm-website-section-context|{ context }| alias=alias>
+        <marko-web-gtm-push data=context />
         $ const gtmData = { ...context, identityX };
         <marko-web-gtm-push data=gtmData />
-      </marko-web-gtm-default-context>
+      </marko-web-gtm-website-section-context>
     </@head>
     <@section|{ blockName, section }| modifiers=["break-container", "top250"]>
       <graphic-header />

--- a/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
+++ b/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
@@ -101,9 +101,9 @@ $ const guide = get(top250, `guides.${guideAlias}`);
           <div class="row mb-3">
             <div class="col">
               <h1 class="page-wrapper__website-section-name">
-                <a href=`/${top250.rootAlias}`>${top250.title}</a>
+                <a href=`/${top250.rootAlias}`>$!{top250.title}</a>
               </h1>
-              <h1 class="page-wrapper__website-section-subhead">${guide.title}</h1>
+              <h1 class="page-wrapper__website-section-subhead">$!{guide.title}</h1>
             </div>
           </div>
           <div class="row">

--- a/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
+++ b/sites/ccjdigital.com/server/templates/website-section/top250/guide.marko
@@ -1,137 +1,138 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 
-$ const { site } = out.global;
+$ const { site, req } = out.global;
 $ const top250 = site.getAsObject("top250");
-$ const { title, description, alias } = data;
+$ const guideAlias = req.path.split('/')[2];
+$ const { id, alias, name, pageNode } = input;
 
-$ const guide = get(top250, `guides.${alias}`);
+$ const guide = get(top250, `guides.${guideAlias}`);
 
 <idx-gating|{ context: idxContext, hasRequiredFields, fields }|>
   $ const canAccess = idxContext.hasUser && hasRequiredFields;
   $ const identityX = { user: idxContext.user, hasRequiredFields, fields}
-  <marko-web-default-page-layout type="top250" title=guide.title description=guide.description>
+  <global-website-section-default-layout
+    id=id
+    alias=alias
+    name=name
+    page-node=pageNode
+  >
     <@head>
       <marko-web-gtm-default-context|{ context }|>
         $ const gtmData = { ...context, identityX };
         <marko-web-gtm-push data=gtmData />
       </marko-web-gtm-default-context>
     </@head>
-    <@page>
-      <marko-web-page-wrapper>
-        <@section|{ blockName, section }| modifiers=["break-container", "top250"]>
-          <graphic-header />
-        </@section>
-        <@section|{ aliases }| modifiers=["first"]>
-          <global-gam-define-display-ad
-            name="leaderboard"
-            position="section_page"
-            aliases=aliases
-            modifiers=["inter-block"]
-          />
-        </@section>
-        <if(!canAccess)>
-          <@section|{ blockName, section }|>
-            <div class="row">
-              <div class="col-md-6">
-                <marko-web-block class="top250-access">
-                  <h2 class="top250-access__title">
-                    Essential data to drive your business
-                  </h2>
-                  <marko-web-block  class="top250-access__description">
-                    <em>CCJ’s</em> Top 250 data format gives you access to consolidated business intelligence not available anywhere else.
-                  </marko-web-block>
-                  <marko-web-block  class="top250-access__call-to-action">
-                    Unlock the trends propelling the trucking industry’s most successful companies to the top with the <em>CCJ</em> Top 250. Sort real-time stats on fiscal year performance for customizable reporting on revenue, location, fleet type and size, leased vs. owned and driver counts. Track trends and understand your competition with blended, year-to-year data on nine industry segments that tells you where you are now and where you need to go.
-                  </marko-web-block>
+    <@section|{ blockName, section }| modifiers=["break-container", "top250"]>
+      <graphic-header />
+    </@section>
+    <@section|{ aliases }| modifiers=["first"]>
+      <global-gam-define-display-ad
+        name="leaderboard"
+        position="section_page"
+        aliases=aliases
+        modifiers=["inter-block"]
+      />
+    </@section>
+    <if(!canAccess)>
+      <@section|{ blockName, section }|>
+        <div class="row">
+          <div class="col-md-6">
+            <marko-web-block class="top250-access">
+              <h2 class="top250-access__title">
+                Essential data to drive your business
+              </h2>
+              <marko-web-block  class="top250-access__description">
+                <em>CCJ’s</em> Top 250 data format gives you access to consolidated business intelligence not available anywhere else.
+              </marko-web-block>
+              <marko-web-block  class="top250-access__call-to-action">
+                Unlock the trends propelling the trucking industry’s most successful companies to the top with the <em>CCJ</em> Top 250. Sort real-time stats on fiscal year performance for customizable reporting on revenue, location, fleet type and size, leased vs. owned and driver counts. Track trends and understand your competition with blended, year-to-year data on nine industry segments that tells you where you are now and where you need to go.
+              </marko-web-block>
 
-                  <marko-web-block class="top250-login-box">
-                    <marko-web-img
-                      alt="CCJ Top 250 Logo"
-                      src="https://img.ccjdigital.com/files/base/randallreilly/all/image/static/ccj/top250.svg?w=215"
-                      srcset="https://img.ccjdigital.com/files/base/randallreilly/all/image/static/ccj/top250.svg?w=430 2x"
-                      link={ href: "/ccj-top-250", class: "top250-access__logo-link" }
-                      class="top250-access__logo"
-                    />
-                    <marko-web-block class="top250-login-box__description">
-                      The heartbeat of trucking’s top<br />fleets at your fingertips
-                    </marko-web-block>
-                    <marko-web-block class="top250-login-box__form">
-                      <if(idxContext.hasUser)>
-                        <div class="top-250__profile-form">
-                          <marko-web-identity-x-form-profile
-                            call-to-action="Complete the form below to access the CCJ Top 250."
-                            reload-page-on-submit=true
-                          />
-                        </div>
-                      </if>
-                      <else>
-                        <div class="top-250__form--login">
-                          <marko-web-identity-x-form-login
-                            button-labels= {
-                              continue: 'Access the Data',
-                              submit: 'Access the Data',
-                              logout: 'Logout',
-
-                            }
-                          />
-                          <p class="top250-login-box__disclaimer">By providing your email, you agree to our Terms of Use and Privacy Policy. This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply.</p>
-                        </div>
-                      </else>
-                      </marko-web-block>
-                  </marko-web-block>
+              <marko-web-block class="top250-login-box">
+                <marko-web-img
+                  alt="CCJ Top 250 Logo"
+                  src="https://img.ccjdigital.com/files/base/randallreilly/all/image/static/ccj/top250.svg?w=215"
+                  srcset="https://img.ccjdigital.com/files/base/randallreilly/all/image/static/ccj/top250.svg?w=430 2x"
+                  link={ href: "/ccj-top-250", class: "top250-access__logo-link" }
+                  class="top250-access__logo"
+                />
+                <marko-web-block class="top250-login-box__description">
+                  The heartbeat of trucking’s top<br />fleets at your fingertips
                 </marko-web-block>
-              </div>
-              <div class="col-md-6">
-                <marko-web-website-section-name tag="h2" block-name=blockName modifiers=["top250-related-content"] obj=section>
-                  Related Stories
-                </marko-web-website-section-name>
-                <global-section-feed-block alias='ccj-top-250' modifiers=["top250"]>
-                  <@query-params limit=5 skip=0 />
-                </global-section-feed-block>
+                <marko-web-block class="top250-login-box__form">
+                  <if(idxContext.hasUser)>
+                    <div class="top-250__profile-form">
+                      <marko-web-identity-x-form-profile
+                        call-to-action="Complete the form below to access the CCJ Top 250."
+                        reload-page-on-submit=true
+                      />
+                    </div>
+                  </if>
+                  <else>
+                    <div class="top-250__form--login">
+                      <marko-web-identity-x-form-login
+                        button-labels= {
+                          continue: 'Access the Data',
+                          submit: 'Access the Data',
+                          logout: 'Logout',
+                        }
+                      />
+                      <p class="top250-login-box__disclaimer">By providing your email, you agree to our Terms of Use and Privacy Policy. This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply.</p>
+                    </div>
+                  </else>
+                  </marko-web-block>
+              </marko-web-block>
+            </marko-web-block>
+          </div>
+          <div class="col-md-6">
+            <marko-web-website-section-name tag="h2" block-name=blockName modifiers=["top250-related-content"] obj=section>
+              Related Stories
+            </marko-web-website-section-name>
+            <global-section-feed-block alias='ccj-top-250' modifiers=["top250"]>
+              <@query-params limit=5 skip=0 />
+            </global-section-feed-block>
+          </div>
+        </div>
+      </@section>
+    </if>
+    <else>
+      <@section>
+        <div class="top250-container">
+          <div class="row mb-3">
+            <div class="col">
+              <h1 class="page-wrapper__website-section-name">
+                <a href=`/${top250.rootAlias}`>${top250.title}</a>
+              </h1>
+              <h1 class="page-wrapper__website-section-subhead">${guide.title}</h1>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <div class="mb-block">
+                <if(guide)>
+                  <marko-web-resolve|{ resolved }| promise=guide.tableRows>
+                    <data-table
+                      initial-primary-operation=guide.initialPrimaryOperation
+                      columns=guide.columns
+                      table-rows=resolved
+                      sheet-src=guide.sheetSrc
+                      alias=alias
+                    />
+                  </marko-web-resolve>
+                </if>
               </div>
             </div>
-          </@section>
-        </if>
-        <else>
-          <@section>
-            <div class="top250-container">
-              <div class="row mb-3">
-                <div class="col">
-                  <h1 class="page-wrapper__website-section-name">
-                    <a href=`/${top250.rootAlias}`>$!{top250.title}</a>
-                  </h1>
-                  <h1 class="page-wrapper__website-section-subhead">${guide.title}</h1>
-                </div>
-              </div>
-              <div class="row">
-                <div class="col">
-                  <div class="mb-block">
-                    <if(guide)>
-                      <marko-web-resolve|{ resolved }| promise=guide.tableRows>
-                        <data-table
-                          initial-primary-operation=guide.initialPrimaryOperation
-                          columns=guide.columns
-                          table-rows=resolved
-                          sheet-src=guide.sheetSrc
-                          alias=alias
-                        />
-                      </marko-web-resolve>
-                    </if>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </@section>
-        </else>
-        <@section|{ aliases }| modifiers=["first"]>
-          <global-gam-define-display-ad
-            name="leaderboard"
-            position="section_page"
-            aliases=aliases
-            modifiers=["inter-block"]
-          />
-        </@section>
-      </marko-web-page-wrapper>
-    </@page>
-  </marko-web-default-page-layout>
+          </div>
+        </div>
+      </@section>
+    </else>
+    <@section|{ aliases }| modifiers=["first"]>
+      <global-gam-define-display-ad
+        name="leaderboard"
+        position="section_page"
+        aliases=aliases
+        modifiers=["inter-block"]
+      />
+    </@section>
+  </global-website-section-default-layout>
 </idx-gating>

--- a/sites/ccjdigital.com/server/templates/website-section/top250/index.marko
+++ b/sites/ccjdigital.com/server/templates/website-section/top250/index.marko
@@ -15,10 +15,11 @@ $ const perPage = 18;
     page-node=pageNode
   >
     <@head>
-      <marko-web-gtm-default-context|{ context }|>
+      <marko-web-gtm-website-section-context|{ context }| alias=alias>
+        <marko-web-gtm-push data=context />
         $ const gtmData = { ...context, identityX };
         <marko-web-gtm-push data=gtmData />
-      </marko-web-gtm-default-context>
+      </marko-web-gtm-website-section-context>
     </@head>
 
     <@section|{ blockName, section }| modifiers=["break-container", "top250"]>


### PR DESCRIPTION
Update CCJ top 250 guide routes to use the global website section default layout and root(ccj-top-250) website section context.

All guides and the section landing page should use the related section context for ccj top 250.  So on ccj-top-250/all it should still load the site section context for ccj-top-250 section, but display the guide/chart for all operations.