### PR TITLE
Add nodelist sectionfeed css & ol/ul style position change

### DIFF
--- a/packages/global/scss/components/_content-page.scss
+++ b/packages/global/scss/components/_content-page.scss
@@ -120,6 +120,35 @@
         text-decoration: none;
       }
     }
+    .node-list {
+      &--gray-background {
+        background-color: $gray-100;
+      }
+    }
+    .section-feed-content-node {
+      &__content-short-name {
+        font-size: 20px;
+        line-height: 1em;
+      }
+      &__image-wrapper {
+        width: 125px;
+        min-width: 125px;
+        height: 83px;
+        @include media-breakpoint-up(md) {
+          width: 198px;
+          min-width: 198px;
+          height: 131px;
+        }
+      }
+      &__image {
+        width: 125px;
+        height: 83px;
+        @include media-breakpoint-up(md) {
+          width: 198px;
+          height: 131px;
+        }
+      }
+    }
   }
 
   &__content-body h2,
@@ -129,6 +158,11 @@
     @include media-breakpoint-down(sm) {
       font-size: 23px;
     }
+  }
+
+  &__content-body ol,
+  &__content-body ul {
+    list-style-position: initial;
   }
 
   &--download-form {


### PR DESCRIPTION
These changes will make the node-list with section-feed nodes have the same look & functionality, but with minor image and title size adjustments.

The ordered and unorderd list will now have the standard list position instead of inside it was picking up from the mixin css

![2021-small-fleet](https://user-images.githubusercontent.com/3845869/131391149-c9001541-37b6-4568-946c-0c5fb4cbca5b.jpeg)
![2021-small-fleet-mobile](https://user-images.githubusercontent.com/3845869/131391161-8290fa2c-5cf4-4625-972a-afff5416f651.jpeg)
