### PR TITLE
Alter ad positions from visibility of site header.

### DIFF
--- a/packages/global/components/gam/wallpaper-ad.marko
+++ b/packages/global/components/gam/wallpaper-ad.marko
@@ -9,4 +9,28 @@ $ const blockName = "wallpaper-ad";
   <marko-web-element block-name=blockName name="right">
     <global-gam-define-display-ad name="wallpaper-right" position=position aliases=aliases show-label=false />
   </marko-web-element>
+  <script>
+  function isNotInViewport(element) {
+    const currentElement = element.getBoundingClientRect();
+    return (
+        currentElement.bottom <= 0
+    );
+  }
+  const elementToCheck = document.querySelector('.site-header');
+  const leftWallpaper = document.querySelector('.wallpaper-ad__left')
+  const rightWallpaper = document.querySelector('.wallpaper-ad__right')
+
+  document.addEventListener('scroll', function () {
+    const checkViewPort = isNotInViewport(elementToCheck)
+    if(checkViewPort){
+      leftWallpaper.style.position = "fixed";
+      rightWallpaper.style.position = "fixed";
+    } else {
+      leftWallpaper.removeAttribute("style");
+      rightWallpaper.removeAttribute("style");
+    }
+  }, {
+    passive: true
+  });
+  </script>
 </marko-web-block>


### PR DESCRIPTION
This utilizes checking if the site header is still visible (this could be changed to any element prior to these in the DOM or if the script is moved to the footer or somewhere "lower" in the DOM an element that appears across all pages, I thought the header was a good choice since it should always be there). Once that element is no longer visible the position attribute of the wallpapers is adjusted to make them "sticky" until the element is visible again in which it will then return to it's original position it was located upon page load. I tried looking into getting a smoother transition between this toggle but any translations resulted in the ads stacking on top of each other rather than just shifting up.

<img width="1920" alt="Screen Shot 2021-10-19 at 10 10 41 AM" src="https://user-images.githubusercontent.com/46794001/137940805-458aafae-fb28-4f33-abd8-76ec3a91ea45.png">
