### PR TITLE
Create custom redirect middleware to handle /?p={WORDPRESS_POST_ID} on homepages.

### DIFF
--- a/packages/global/middleware/post-id-handler.js
+++ b/packages/global/middleware/post-id-handler.js
@@ -1,0 +1,39 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { get } = require('@parameter1/base-cms-object-path');
+const gql = require('graphql-tag');
+
+const query = gql`
+  query allPublishedContent($input: AllPublishedContentQueryInput!) {
+    allPublishedContent(input: $input){
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * @param {object} req The Express request object.
+ * @param {String} sitePostDomain The post domain to query against (ex: wordpress.ccjdigital.posts).
+ */
+async function findPost(req, sitePostDomain) {
+  const { apollo, query: params } = req;
+  const variables = { input: { importEntity: `${sitePostDomain}*${params.p}` } };
+  const { data } = await apollo.query({ query, variables });
+  const { allPublishedContent } = data;
+  const edges = get(allPublishedContent, 'edges');
+  if (edges.length) {
+    return { from: `/?p=${params.p}`, to: `/${edges[0].node.id}`, code: 301 };
+  }
+  return null;
+}
+
+module.exports = ({ sitePostDomain } = {}) => asyncRoute(async (req, res, next) => {
+  const { p } = req.query;
+  if (!p || !sitePostDomain) return next();
+  const redirect = await findPost(req, sitePostDomain);
+  if (redirect) return res.redirect(redirect.code, redirect.to);
+  return next();
+});

--- a/packages/global/middleware/post-id-handler.js
+++ b/packages/global/middleware/post-id-handler.js
@@ -16,11 +16,10 @@ const query = gql`
 
 /**
  * @param {object} req The Express request object.
- * @param {String} sitePostDomain The post domain to query against (ex: wordpress.ccjdigital.posts).
  */
-async function findPost(req, sitePostDomain) {
+async function findPost(req) {
   const { apollo, query: params } = req;
-  const variables = { input: { importEntity: `${sitePostDomain}*${params.p}` } };
+  const variables = { input: { customAttributes: { key: 'wpPostId', value: params.p }, withSite: true } };
   const { data } = await apollo.query({ query, variables });
   const { allPublishedContent } = data;
   const edges = get(allPublishedContent, 'edges');
@@ -30,10 +29,10 @@ async function findPost(req, sitePostDomain) {
   return null;
 }
 
-module.exports = ({ sitePostDomain } = {}) => asyncRoute(async (req, res, next) => {
+module.exports = () => asyncRoute(async (req, res, next) => {
   const { p } = req.query;
-  if (!p || !sitePostDomain) return next();
-  const redirect = await findPost(req, sitePostDomain);
+  if (!p) return next();
+  const redirect = await findPost(req);
   if (redirect) return res.redirect(redirect.code, redirect.to);
   return next();
 });

--- a/sites/ccjdigital.com/server/routes/home.js
+++ b/sites/ccjdigital.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.ccjdigital.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/ccjdigital.com/server/routes/home.js
+++ b/sites/ccjdigital.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.ccjdigital.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/equipmentworld.com/server/routes/home.js
+++ b/sites/equipmentworld.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.equipmentworld.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/equipmentworld.com/server/routes/home.js
+++ b/sites/equipmentworld.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.equipmentworld.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/hardworkingtrucks.com/server/routes/home.js
+++ b/sites/hardworkingtrucks.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.hardworkingtrucks.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/hardworkingtrucks.com/server/routes/home.js
+++ b/sites/hardworkingtrucks.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.hardworkingtrucks.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/overdriveonline.com/server/routes/home.js
+++ b/sites/overdriveonline.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.overdriveonline.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/overdriveonline.com/server/routes/home.js
+++ b/sites/overdriveonline.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.overdriveonline.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/totallandscapecare.com/server/routes/home.js
+++ b/sites/totallandscapecare.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.totallandscapecare.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/totallandscapecare.com/server/routes/home.js
+++ b/sites/totallandscapecare.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.totallandscapecare.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckersnews.com/server/routes/home.js
+++ b/sites/truckersnews.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.truckersnews.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckersnews.com/server/routes/home.js
+++ b/sites/truckersnews.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.truckersnews.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckpartsandservice.com/server/routes/home.js
+++ b/sites/truckpartsandservice.com/server/routes/home.js
@@ -1,10 +1,10 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-global/graphql/fragments/website-section-page');
-// const postIdHandler = require('@randall-reilly/package-shared/middleware/post-id-handler');
+const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
+  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.truckpartsandservice.posts' }), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckpartsandservice.com/server/routes/home.js
+++ b/sites/truckpartsandservice.com/server/routes/home.js
@@ -4,7 +4,7 @@ const postIdHandler = require('@randall-reilly/package-global/middleware/post-id
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler({ sitePostDomain: 'wordpress.truckpartsandservice.posts' }), withWebsiteSection({
+  app.get('/', postIdHandler(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-11-30 at 8 55 26 AM" src="https://user-images.githubusercontent.com/46794001/144070754-30b9483d-dd31-4d07-8b5f-59c1ee6faa33.png">
<img width="1920" alt="Screen Shot 2021-11-30 at 8 55 31 AM" src="https://user-images.githubusercontent.com/46794001/144070680-dc115e46-8e88-4812-9a54-c6e653d0d35d.png">

This will require a dependency upgrade following the merge of https://github.com/parameter1/base-cms/pull/202

EDIT: Scratch the dep upgrade, forgot the GraphQL server is completely separate from anything in the sites.