### PR TITLE
Remove ‘TBS’ logo from ‘partners in business’

### DIFF
--- a/sites/overdriveonline.com/config/site.js
+++ b/sites/overdriveonline.com/config/site.js
@@ -72,13 +72,6 @@ module.exports = {
       width: '109px',
     },
   },
-  // sponsoredSectionLogos: {
-  //   'partners-in-business': {
-  //     src: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/pib-tbs-logo.png?auto=format&w=88&fit=crop',
-  //     width: '88px',
-  //     height: '55px',
-  //   },
-  // },
   sponsoredSectionNameLogos: {
     gear: {
       src: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/ovd/trucker-gear-logo.png?auto=format&w=275&fit=crop',

--- a/sites/overdriveonline.com/config/site.js
+++ b/sites/overdriveonline.com/config/site.js
@@ -72,13 +72,13 @@ module.exports = {
       width: '109px',
     },
   },
-  sponsoredSectionLogos: {
-    'partners-in-business': {
-      src: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/pib-tbs-logo.png?auto=format&w=88&fit=crop',
-      width: '88px',
-      height: '55px',
-    },
-  },
+  // sponsoredSectionLogos: {
+  //   'partners-in-business': {
+  //     src: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/pib-tbs-logo.png?auto=format&w=88&fit=crop',
+  //     width: '88px',
+  //     height: '55px',
+  //   },
+  // },
   sponsoredSectionNameLogos: {
     gear: {
       src: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/ovd/trucker-gear-logo.png?auto=format&w=275&fit=crop',

--- a/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
+++ b/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
@@ -8,7 +8,7 @@ $ const perPage = 18;
 
 $ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static";
 $ const logoSrcs = [
-  "pib-tbs-logo.png?auto=format&w=88&fit=crop",
+  <!-- "pib-tbs-logo.png?auto=format&w=88&fit=crop", -->
   "pib-atbs-logo.png?auto=format&w=148&fit=crop",
 ];
 $ const manualSrc = "pib-issue-cover.png?auto=format&w=120&fit=crop";
@@ -47,12 +47,12 @@ $ const manualSrc = "pib-issue-cover.png?auto=format&w=120&fit=crop";
               srcset=[`${logoRoot}/${logoSrcs[0]}&dpr=2 2x`]
               alt="TBS Factoring Service Logo"
             />
-            <marko-web-img
+            <!-- <marko-web-img
               class=`${blockName}__partner-logo-2`
               src=`${logoRoot}/${logoSrcs[1]}`
               srcset=[`${logoRoot}/${logoSrcs[1]}&dpr=2 2x`]
               alt="TBS Logo"
-            />
+            /> -->
           </marko-web-element>
         </marko-web-element>
       </marko-web-element>

--- a/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
+++ b/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
@@ -8,7 +8,6 @@ $ const perPage = 18;
 
 $ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static";
 $ const logoSrcs = [
-  <!-- "pib-tbs-logo.png?auto=format&w=88&fit=crop", -->
   "pib-atbs-logo.png?auto=format&w=148&fit=crop",
 ];
 $ const manualSrc = "pib-issue-cover.png?auto=format&w=120&fit=crop";
@@ -47,12 +46,6 @@ $ const manualSrc = "pib-issue-cover.png?auto=format&w=120&fit=crop";
               srcset=[`${logoRoot}/${logoSrcs[0]}&dpr=2 2x`]
               alt="TBS Factoring Service Logo"
             />
-            <!-- <marko-web-img
-              class=`${blockName}__partner-logo-2`
-              src=`${logoRoot}/${logoSrcs[1]}`
-              srcset=[`${logoRoot}/${logoSrcs[1]}&dpr=2 2x`]
-              alt="TBS Logo"
-            /> -->
           </marko-web-element>
         </marko-web-element>
       </marko-web-element>


### PR DESCRIPTION
Current:
<img width="845" alt="Screen Shot 2021-12-15 at 12 17 22 PM" src="https://user-images.githubusercontent.com/64623209/146242712-4306972c-1239-42fb-b998-a33fcdf1c005.png">
<img width="811" alt="Screen Shot 2021-12-15 at 12 17 28 PM" src="https://user-images.githubusercontent.com/64623209/146242729-d208813f-d79d-413a-9e66-1a2b7aaf7a9b.png">

Change:
<img width="836" alt="Screen Shot 2021-12-15 at 12 16 00 PM" src="https://user-images.githubusercontent.com/64623209/146242610-70ceb849-f28b-403b-a823-5047646e0baf.png">
<img width="915" alt="Screen Shot 2021-12-15 at 12 16 12 PM" src="https://user-images.githubusercontent.com/64623209/146242623-78899af7-7d63-4886-a56d-79fcbe7239b7.png">
