### PR TITLE
Revert navbar logo height back to original

### DIFF
--- a/packages/theme-monorail/scss/_variables.scss
+++ b/packages/theme-monorail/scss/_variables.scss
@@ -157,7 +157,7 @@ $theme-site-header-breakpoints: map-merge(
 $skin-desktop-menu-breakpoint: map-get($theme-site-header-breakpoints, hide-secondary);
 $theme-site-navbar-brand-margin-x: 36px !default;
 
-$theme-site-navbar-logo-height: 65px !default;
+$theme-site-navbar-logo-height: 46px !default;
 $theme-site-navbar-logo-height-sm: 35px !default;
 
 $theme-site-navbar-primary-height-sm: 0;


### PR DESCRIPTION
This change is for all brands
<img width="1149" alt="Screen Shot 2022-03-04 at 9 07 10 AM" src="https://user-images.githubusercontent.com/64623209/156787879-f6c9ab25-1ea2-4c5a-8d32-d36b3452b2ba.png">
