### PR TITLE
Update to Content Meter: When to displays ||  Verbiage on remaining views || CLS on initial display of bar

### DIFF
--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -6,11 +6,12 @@ $ const {
 } = input.contentMeterState;
 
 $ const { config } = out.global;
+$ const dynamicTitle = (viewLimit - views === 1) ? 'You have one article view remaining.' : `You have ${viewLimit - views} article views remaining.`;
 
 $ function setTextVariables() {
   if (views < viewLimit) {
     return [
-      `You have ${viewLimit - views} article views remaining.`,
+      dynamicTitle,
       `Create a free account`,
       `Create a free ${config.siteName()} account to continue reading`,
       'Create Account'

--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -6,19 +6,15 @@ $ const {
 } = input.contentMeterState;
 
 $ const { config } = out.global;
-$ const dynamicTitle = (viewLimit - views === 1) ? 'You have one article view remaining.' : `You have ${viewLimit - views} article views remaining.`;
 
 $ function setTextVariables() {
-  if (views < viewLimit) {
-    return [
-      dynamicTitle,
-      `Create a free account`,
-      `Create a free ${config.siteName()} account to continue reading`,
-      'Create Account'
-    ];
-  }
+  // Set title based on views remaining
+  let dynamicTitle = 'We hope you’ve enjoyed your articles.'
+  if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
+  if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
+
   return [
-    'We hope you’ve enjoyed your articles.',
+    dynamicTitle,
     'Create a free account',
     `Create a free ${config.siteName()} account to continue reading`,
     'Continue',

--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -10,8 +10,8 @@ $ const { config } = out.global;
 $ function setTextVariables() {
   // Set title based on views remaining
   let dynamicTitle = 'We hope you’ve enjoyed your articles.'
-  if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
   if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
+  if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
 
   return [
     dynamicTitle,

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -88,10 +88,10 @@ $ const {
   </@above-container>
   <@below-container>
     <${input.belowContainer} />
-    <theme-site-footer />
     <if(contentMeterState && !contentMeterState.isLoggedIn)>
       <global-content-meter-block content-meter-state=contentMeterState />
     </if>
+    <theme-site-footer />
   </@below-container>
   <@below-wrapper>
     <marko-web-deferred-script-loader-load />

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -85,13 +85,13 @@ $ const {
     </marko-web-identity-x-context>
     <theme-site-newsletter-menu />
     <${input.aboveContainer} />
+    <if(contentMeterState && !contentMeterState.isLoggedIn)>
+      <global-content-meter-block content-meter-state=contentMeterState />
+    </if>
   </@above-container>
   <@below-container>
     <${input.belowContainer} />
     <theme-site-footer />
-    <if(contentMeterState && !contentMeterState.isLoggedIn)>
-      <global-content-meter-block content-meter-state=contentMeterState />
-    </if>
   </@below-container>
   <@below-wrapper>
     <marko-web-deferred-script-loader-load />

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -85,13 +85,13 @@ $ const {
     </marko-web-identity-x-context>
     <theme-site-newsletter-menu />
     <${input.aboveContainer} />
-    <if(contentMeterState && !contentMeterState.isLoggedIn)>
-      <global-content-meter-block content-meter-state=contentMeterState />
-    </if>
   </@above-container>
   <@below-container>
     <${input.belowContainer} />
     <theme-site-footer />
+    <if(contentMeterState && !contentMeterState.isLoggedIn)>
+      <global-content-meter-block content-meter-state=contentMeterState />
+    </if>
   </@below-container>
   <@below-wrapper>
     <marko-web-deferred-script-loader-load />

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -65,7 +65,8 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
   const olyEncId = idFromQuery || idFromCookie;
 
-  if (!config.enable || olyEncId || (isLoggedIn && !requiresUserInput));
+  // If disabled, not logged in & have a oly_enc_id or logged in and have all required fields
+  if (!config.enable || (!isLoggedIn && olyEncId) || (isLoggedIn && !requiresUserInput));
 
   else if (isLoggedIn && requiresUserInput && await shouldMeter(req)) {
     res.locals.contentMeterState = {

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -90,7 +90,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
       valid.push({ id, viewed: now });
     }
 
-    const displayGate = (valid.length === config.viewLimit && !valid.find(v => v.id === id));
+    const displayGate = (valid.length >= config.viewLimit && !valid.find(v => v.id === id));
 
     res.locals.contentMeterState = {
       ...config,

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -108,8 +108,10 @@ $content-meter-mobile-breakpoint: 600px !default;
       }
       &__body {
         display: flex;
+        min-height: 108px;
         @media (min-width: $content-meter-mobile-breakpoint) {
           justify-content: center;
+          min-height: 48px;
         }
       }
     }

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -2,7 +2,6 @@ $content-meter-mobile-breakpoint: 600px !default;
 .content-meter {
   $self: &;
   &__overlay {
-    z-index: 1499;
     position: fixed;
     background-color: rgba(0, 0, 0, .7);
     top: 0;

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -1,7 +1,11 @@
 $content-meter-mobile-breakpoint: 600px !default;
 .content-meter {
   $self: &;
+  ~ .site-footer {
+    margin-bottom: 72px;
+  }
   &__overlay {
+    z-index: 1499;
     position: fixed;
     background-color: rgba(0, 0, 0, .7);
     top: 0;
@@ -93,6 +97,12 @@ $content-meter-mobile-breakpoint: 600px !default;
   }
 
   &--open {
+    ~ .site-footer {
+      margin-bottom: 296px;
+      @media (min-width: $content-meter-mobile-breakpoint) {
+        margin-bottom: 166px;
+      }
+    }
     #{ $self } {
       &__bar {
         padding-bottom: map-get($spacers, 4);

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -2,6 +2,7 @@ $content-meter-mobile-breakpoint: 600px !default;
 .content-meter {
   $self: &;
   &__overlay {
+    z-index: 1499;
     position: fixed;
     background-color: rgba(0, 0, 0, .7);
     top: 0;


### PR DESCRIPTION
Update check to enabled, not logged in & oyl_enc_id is set or logged in and all required fields are met.

update verbiage to show  if one view remains `You have 1 article view remaining.` or `You have ${viewLimit - views} article views remaining.`

<img width="694" alt="Screen Shot 2022-03-09 at 2 30 14 PM" src="https://user-images.githubusercontent.com/3845869/157531081-11a676c7-49f9-41dc-94f0-54346750f2cb.png">
<img width="710" alt="Screen Shot 2022-03-09 at 2 32 45 PM" src="https://user-images.githubusercontent.com/3845869/157531088-f70d7817-0abf-41a7-b28b-4f6bcc762041.png">
<img width="713" alt="Screen Shot 2022-03-09 at 2 33 14 PM" src="https://user-images.githubusercontent.com/3845869/157531091-ec5a01f1-175a-4ce1-882a-80cff032c7d1.png">


Also add min height css on login form wrapper to prevent the bar height from changing while waiting on the idX login form to render.  
