### PR TITLE
Move newsletter middleware to specific sites and move setting of initiallyExpanded within middleware

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -36,8 +36,8 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
         aliases=aliases
         modifiers=["inter-block"]
       />
+      <theme-gam-wallpaper-ad aliases=aliases position="content_page" />
     </if>
-    <theme-gam-wallpaper-ad aliases=aliases position="content_page" />
   </@section>
 
   <@section|{ blockName, content, aliases, authors }| modifiers=["content-header"]>

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -16,6 +16,6 @@ module.exports = () => (req, res, next) => {
     res.cookie(cookieName, true, { maxAge });
   }
 
-  res.locals.newsletterState = { hasCookie, fromEmail, initiallyExpanded };
+  res.locals.newsletterState = { initiallyExpanded };
   next();
 };

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -7,6 +7,7 @@ module.exports = () => (req, res, next) => {
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
+  const initiallyExpanded = !(hasCookie || fromEmail);
 
   if (!hasCookie) {
     // Expire in 14 days (2yr if already signed up)
@@ -15,6 +16,6 @@ module.exports = () => (req, res, next) => {
     res.cookie(cookieName, true, { maxAge });
   }
 
-  res.locals.newsletterState = { hasCookie, fromEmail };
+  res.locals.newsletterState = { hasCookie, fromEmail, initiallyExpanded };
   next();
 };

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -11,7 +11,6 @@ const components = require('./components');
 const fragments = require('./fragments');
 const sharedRoutes = require('./routes');
 const paginated = require('./middleware/paginated');
-const newsletterState = require('./middleware/newsletter-state');
 const redirectHandler = require('./redirect-handler');
 const oembedHandler = require('./oembed-handler');
 const omedaConfig = require('./config/omeda');
@@ -53,9 +52,6 @@ module.exports = (options = {}) => {
 
       // Use paginated middleware
       app.use(htmlSitemapPagination());
-
-      // Use newsletterState middleware
-      app.use(newsletterState());
 
       // Setup IdentityX + Omeda
       const idxConfig = getAsObject(options, 'siteConfig.identityX');

--- a/packages/theme-monorail/components/site-newsletter-menu.marko
+++ b/packages/theme-monorail/components/site-newsletter-menu.marko
@@ -13,8 +13,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.pushdown");
 
-$ const { hasCookie, fromEmail } = getAsObject(out.global, "newsletterState");
-$ const initiallyExpanded = (!hasCookie && !fromEmail) ? true : false;
+$ const { hasCookie, fromEmail, initiallyExpanded } = getAsObject(out.global, "newsletterState");
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
 $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
 

--- a/packages/theme-monorail/components/site-newsletter-menu.marko
+++ b/packages/theme-monorail/components/site-newsletter-menu.marko
@@ -13,7 +13,7 @@ $ const {
   privacyPolicy,
 } = site.getAsObject("newsletter.pushdown");
 
-$ const { hasCookie, fromEmail, initiallyExpanded } = getAsObject(out.global, "newsletterState");
+$ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
 $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
 

--- a/sites/ccjdigital.com/server/routes/content.js
+++ b/sites/ccjdigital.com/server/routes/content.js
@@ -2,33 +2,34 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/ccjdigital.com/server/routes/home.js
+++ b/sites/ccjdigital.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/ccjdigital.com/server/routes/website-section.js
+++ b/sites/ccjdigital.com/server/routes/website-section.js
@@ -1,14 +1,15 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/:alias(products)', withWebsiteSection({
+  app.get('/:alias(products)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/equipmentworld.com/server/routes/content.js
+++ b/sites/equipmentworld.com/server/routes/content.js
@@ -2,6 +2,7 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const deathByTrench = require('../templates/content/death-by-trench');
 const product = require('../templates/content/product');
@@ -9,32 +10,32 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/death-by-trench/*?:id(\\d{8})*', withContent({
+  app.get('/death-by-trench/*?:id(\\d{8})*', newsletterState(), withContent({
     template: deathByTrench,
     queryFragment,
   }));
 
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/equipmentworld.com/server/routes/home.js
+++ b/sites/equipmentworld.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/equipmentworld.com/server/routes/website-section.js
+++ b/sites/equipmentworld.com/server/routes/website-section.js
@@ -1,5 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const products = require('../templates/website-section/products');
 const deathByTrench = require('../templates/website-section/death-by-trench');
 const safetyWatch = require('../templates/website-section/safety-watch');
@@ -29,30 +30,30 @@ const coty = [
 
 module.exports = (app) => {
   coty.forEach(({ alias, template, ...rest }) => {
-    app.get(`/:alias(${alias})`, withWebsiteSection({
+    app.get(`/:alias(${alias})`, newsletterState(), withWebsiteSection({
       template,
       queryFragment,
       ...rest,
     }));
   });
 
-  app.get('/:alias(death-by-trench)', withWebsiteSection({
+  app.get('/:alias(death-by-trench)', newsletterState(), withWebsiteSection({
     template: deathByTrench,
     queryFragment,
   }));
-  app.get('/:alias(products)', withWebsiteSection({
+  app.get('/:alias(products)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias(safety-watch)', withWebsiteSection({
+  app.get('/:alias(safety-watch)', newsletterState(), withWebsiteSection({
     template: safetyWatch,
     queryFragment,
   }));
-  app.get('/:alias(safety-watch/[a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias(safety-watch/[a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: safetyWatch,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/hardworkingtrucks.com/server/routes/content.js
+++ b/sites/hardworkingtrucks.com/server/routes/content.js
@@ -2,33 +2,34 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/hardworkingtrucks.com/server/routes/home.js
+++ b/sites/hardworkingtrucks.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/overdriveonline.com/server/routes/content.js
+++ b/sites/overdriveonline.com/server/routes/content.js
@@ -2,33 +2,34 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/overdriveonline.com/server/routes/home.js
+++ b/sites/overdriveonline.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/overdriveonline.com/server/routes/website-section.js
+++ b/sites/overdriveonline.com/server/routes/website-section.js
@@ -1,5 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const partnersInBusiness = require('../templates/website-section/partners-in-business');
 const products = require('../templates/website-section/products');
 const readerRigs = require('../templates/website-section/reader-rigs');
@@ -7,20 +8,20 @@ const rrSubmission = require('../templates/new-reader-rigs-submission');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/new-reader-rigs-submission', (_, res) => { res.marko(rrSubmission); });
-  app.get('/:alias(gear)', withWebsiteSection({
+  app.get('/new-reader-rigs-submission', newsletterState(), (_, res) => { res.marko(rrSubmission); });
+  app.get('/:alias(gear)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias(partners-in-business)', withWebsiteSection({
+  app.get('/:alias(partners-in-business)', newsletterState(), withWebsiteSection({
     template: partnersInBusiness,
     queryFragment,
   }));
-  app.get('/:alias(reader-rigs)', withWebsiteSection({
+  app.get('/:alias(reader-rigs)', newsletterState(), withWebsiteSection({
     template: readerRigs,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/totallandscapecare.com/server/routes/content.js
+++ b/sites/totallandscapecare.com/server/routes/content.js
@@ -2,33 +2,34 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/totallandscapecare.com/server/routes/home.js
+++ b/sites/totallandscapecare.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/totallandscapecare.com/server/routes/website-section.js
+++ b/sites/totallandscapecare.com/server/routes/website-section.js
@@ -1,14 +1,15 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/:alias(products)', withWebsiteSection({
+  app.get('/:alias(products)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/truckersnews.com/server/routes/content.js
+++ b/sites/truckersnews.com/server/routes/content.js
@@ -2,33 +2,34 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/truckersnews.com/server/routes/home.js
+++ b/sites/truckersnews.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckersnews.com/server/routes/website-section.js
+++ b/sites/truckersnews.com/server/routes/website-section.js
@@ -1,14 +1,15 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/:alias(gear)', withWebsiteSection({
+  app.get('/:alias(gear)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));

--- a/sites/truckpartsandservice.com/server/routes/content.js
+++ b/sites/truckpartsandservice.com/server/routes/content.js
@@ -2,6 +2,7 @@ const withContent = require('@randall-reilly/package-global/middleware/with-cont
 const contentMeter = require('@randall-reilly/package-global/middleware/content-meter');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/content-page');
 const contact = require('@randall-reilly/package-global/templates/content/contact');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const company = require('../templates/content/company');
 const product = require('../templates/content/product');
 const whitepaper = require('../templates/content/whitepaper');
@@ -10,27 +11,27 @@ const content = require('../templates/content');
 const companyFragment = require('../graphql/company-page-fragment');
 
 module.exports = (app) => {
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState(), withContent({
     template: company,
     queryFragment: companyFragment,
   }));
 
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState(), withContent({
     template: contact,
     queryFragment,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState(), withContent({
     template: product,
     queryFragment,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState(), withContent({
     template: whitepaper,
     queryFragment,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', contentMeter(), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState(), contentMeter(), withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/truckpartsandservice.com/server/routes/home.js
+++ b/sites/truckpartsandservice.com/server/routes/home.js
@@ -1,10 +1,11 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
 const postIdHandler = require('@randall-reilly/package-global/middleware/post-id-handler');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const home = require('../templates/index');
 
 module.exports = (app) => {
-  app.get('/', postIdHandler(), withWebsiteSection({
+  app.get('/', postIdHandler(), newsletterState(), withWebsiteSection({
     aliasResolver: () => 'home',
     template: home,
     queryFragment,

--- a/sites/truckpartsandservice.com/server/routes/website-section.js
+++ b/sites/truckpartsandservice.com/server/routes/website-section.js
@@ -1,5 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@randall-reilly/package-theme-monorail/graphql/fragments/website-section-page');
+const newsletterState = require('@randall-reilly/package-global/middleware/newsletter-state');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
 
@@ -9,20 +10,20 @@ const directorySection = require('../templates/website-section/directory/_alias'
 const directoryAlias = 'aftermarket-truck-parts-suppliers';
 
 module.exports = (app) => {
-  app.get(`/:alias(${directoryAlias})`, withWebsiteSection({
+  app.get(`/:alias(${directoryAlias})`, newsletterState(), withWebsiteSection({
     template: directoryIndex,
     queryFragment,
   }));
-  app.get(`/:alias(${directoryAlias}/[a-z0-9-/]+)`, withWebsiteSection({
+  app.get(`/:alias(${directoryAlias}/[a-z0-9-/]+)`, newsletterState(), withWebsiteSection({
     template: directorySection,
     queryFragment,
   }));
 
-  app.get('/:alias(products)', withWebsiteSection({
+  app.get('/:alias(products)', newsletterState(), withWebsiteSection({
     template: products,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));


### PR DESCRIPTION
Move the newsletterState middleware to content, section & home routes.  In doing so I also update the newsletter pushdown menu logic to look at the local prop being set in the middleware for initiallyExpanded instead of just looking for the lack of cookie & lack of fromEmail.  The only reason hasCookie & fromEmail was set in the prop was to calculate initiallyExpanded.  So instead i just set initiallyExpanded in the prop instead of hasCookie & fromEmail.  
