### PR TITLE
Prevent shuffle of promos on PIB section page, Overdrive.

### DIFF
--- a/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
+++ b/sites/overdriveonline.com/server/templates/website-section/partners-in-business.marko
@@ -64,7 +64,7 @@ $ const manualSrc = "pib-issue-cover.png?auto=format&w=120&fit=crop";
           </marko-web-block>
         </div>
         <div class="col-md-6 mt-md-0 mt-block">
-          <site-promo-card-rotation-block />
+          <global-ovd-pib-manual-promo-block />
         </div>
       </div>
     </if>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-03-25 at 12 50 31 PM" src="https://user-images.githubusercontent.com/46794001/160175124-7c2ada43-34df-478f-b9f0-24204fbbf65d.png">
