### PR TITLE
Correct homepage alias for distributor-of-the-year-archive and changeout SDA logo.

### DIFF
--- a/sites/truckpartsandservice.com/server/templates/index.marko
+++ b/sites/truckpartsandservice.com/server/templates/index.marko
@@ -30,7 +30,7 @@ $ const { id, alias, name, pageNode } = input;
   </@section>
 
   <@section>
-    <theme-section-card-list-block alias="distributor-of-the-year" default-description="Keep up to date on the independent aftermarket’s highest honor" />
+    <theme-section-card-list-block alias="distributor-of-the-year-archive" default-description="Keep up to date on the independent aftermarket’s highest honor" />
   </@section>
 
   <@section>

--- a/sites/truckpartsandservice.com/server/templates/static/successful-dealer-award-nomination.marko
+++ b/sites/truckpartsandservice.com/server/templates/static/successful-dealer-award-nomination.marko
@@ -23,8 +23,8 @@ $ const description = "The Successful Dealer Award was introduced in 2013 and sh
             <marko-web-img
               class="img-fluid"
               alt="Successful Dealer Award"
-              src="https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/logo.png?w=340"
-              srcset="https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/logo.png?w=680 2x"
+              src="https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/SD-Award-logo.png?w=340"
+              srcset="https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/SD-Award-logo.png?w=680 2x"
             />
           </div>
         </div>


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2022-03-28 at 11 07 00 AM" src="https://user-images.githubusercontent.com/46794001/160440812-d569be96-4b74-49a1-887f-4c524ed3c4a2.png">
<img width="1792" alt="Screen Shot 2022-03-28 at 11 07 11 AM" src="https://user-images.githubusercontent.com/46794001/160440825-0339c091-8ca6-410c-bde8-6fb3c674e428.png">
