### PR TITLE
Add ability to add style to the site name in content meter bar

### DIFF
--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -16,7 +16,7 @@ $ function setTextVariables() {
   return [
     dynamicTitle,
     'Create a free account',
-    `Create a free ${config.siteName()} account to continue reading`,
+    `Create a free <span class="content-meter__call-to-action--site-name">${config.siteName()}</span> account to continue reading`,
     'Continue',
   ];
 }
@@ -45,7 +45,7 @@ $ const [title, collapsedTitle, callToAction, registerText] = setTextVariables()
       />
     </div>
     <p class="content-meter__call-to-action">
-      ${callToAction}
+      $!{callToAction}
     </p>
     <div class="content-meter__body">
       <div class="content-meter__login-form">

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -22,6 +22,9 @@ $content-meter-mobile-breakpoint: 600px !default;
         @media (max-width: $content-meter-mobile-breakpoint) {
           text-align: left;
         }
+        &--site-name {
+          font-style: italic;
+        }
       }
       &__body {
         display: none;


### PR DESCRIPTION
<img width="580" alt="Screen Shot 2022-03-28 at 1 18 41 PM" src="https://user-images.githubusercontent.com/3845869/160463389-578b23d4-3137-430c-bd89-4a223d820c51.png">
