### PR TITLE
Temp fix for content meter gate

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -79,18 +79,18 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
             />
           </else-if>
         </if>
-        $ const requiresRegistration = contentMeterState && contentMeterState.requiresUserInput ? contentMeterState.requiresUserInput : get(content, "userRegistration.isCurrentlyRequired");
+        $ const requiresRegistration = (displayOverlay || (!displayOverlay && contentMeterState && contentMeterState.isLoggedIn && contentMeterState.requiresUserInput)) ? true : get(content, "userRegistration.isCurrentlyRequired");
         $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
         <marko-web-identity-x-access|context|
           enabled=requiresRegistration
           required-access-level-ids=accessLevels
         >
-          <if(!context.canAccess || context.requiresUserInput || (contentMeterState && (!contentMeterState.isLoggedIn || contentMeterState.requiresUserInput)))>
+          <if(!context.canAccess || context.requiresUserInput || (displayOverlay && contentMeterState && (!contentMeterState.isLoggedIn || contentMeterState.requiresUserInput)))>
             $ const body = displayOverlay ? getContentPreview({ body: content.body, selector: "p:lt(7)" }) : getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
             <marko-web-content-body block-name=blockName obj={ body } />
 
             <div class="content-page-preview-overlay" />
-            <if(!displayOverlay || (displayOverlay && requiresRegistration))>
+            <if(!displayOverlay && requiresRegistration)>
               <theme-content-page-gate
                 can-access=context.canAccess
                 is-logged-in=context.isLoggedIn

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -96,7 +96,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
       ...config,
       views: valid.length,
       isLoggedIn: false,
-      requiredUserInput: true,
+      requiresUserInput: true,
       displayGate,
     };
     res.cookie(cookieName, JSON.stringify(valid), { maxAge: config.timeframe });


### PR DESCRIPTION
This is a temp fix to update the conditions on when to display the overlay, apply different truncation & display the login/profile box on content pages.  Will put a second PR to clean up template and move conditional checks accordingly. 

 
### First three articles:
<img width="626" alt="Screen Shot 2022-04-01 at 8 28 50 AM" src="https://user-images.githubusercontent.com/3845869/161273805-a9e457da-9973-4ddd-b358-861480078f77.png">
### 
Additional articles not matching the first three:
<img width="589" alt="Screen Shot 2022-04-01 at 8 29 25 AM" src="https://user-images.githubusercontent.com/3845869/161273928-1e5d9b0c-83bc-4bdc-b136-485d78278902.png">

### Revisited one of the first three:
<img width="587" alt="Screen Shot 2022-04-01 at 8 29 42 AM" src="https://user-images.githubusercontent.com/3845869/161273988-792504d4-8475-457e-a550-4a0a45ef4c61.png">

### Revisit one Login is submitted, login link clicked & user has unmeet required fields(Must revisit without filling in provile):
<img width="566" alt="Screen Shot 2022-04-01 at 8 32 52 AM" src="https://user-images.githubusercontent.com/3845869/161274219-73149c41-8292-472b-9db7-c80c71af8559.png">


### Once logged in and required fields are filled in:
<img width="1350" alt="Screen Shot 2022-04-01 at 8 36 29 AM" src="https://user-images.githubusercontent.com/3845869/161274362-1518f9f4-4973-4ff7-b845-22891268c7a6.png">

