### PR TITLE
Add user links to drop down menu

### DIFF
--- a/packages/global/config/identity-x-nav.js
+++ b/packages/global/config/identity-x-nav.js
@@ -7,30 +7,31 @@ module.exports = ({ site }) => {
   if (!enabled) return;
   const defaultTargets = [
     'navigation.desktopMenu.user',
+    'navigation.mobileMenu.user',
   ];
   const targets = site.getAsArray('idxNavItems.navigationTargets').length ? site.getAsArray('idxNavItems.navigationTargets') : defaultTargets;
   const navConfig = [
-    {
-      href: idxConfig.getEndpointFor('login'),
-      label: 'Log In',
-      when: 'logged-out',
-      modifiers: ['user'],
-    },
+    // {
+    //   href: idxConfig.getEndpointFor('login'),
+    //   label: 'Log In',
+    //   when: 'logged-out',
+    //   modifiers: ['user'],
+    // },
     {
       href: idxConfig.getEndpointFor('profile'),
-      label: 'My Account',
+      label: 'Manage Account',
       when: 'logged-in',
       modifiers: ['user'],
     },
     {
       href: idxConfig.getEndpointFor('logout'),
-      label: 'Log Out',
+      label: 'Sign Out',
       when: 'logged-in',
       modifiers: ['user'],
     },
     {
       href: idxConfig.getEndpointFor('register'),
-      label: 'Register',
+      label: 'Sign Up',
       when: 'logged-out',
       modifiers: ['user'],
     },

--- a/packages/theme-monorail/components/site-menu/index.marko
+++ b/packages/theme-monorail/components/site-menu/index.marko
@@ -21,6 +21,18 @@ $ const hasUser = defaultValue(input.hasUser, false);
       <div class="col-6 col-md-4 col-lg-4">
         <!-- search box -->
         <search block-name=blockName />
+        <!-- user section || IDX_NAV_ENABLE -->
+        <if(site.getAsArray("navigation.desktopMenu.user"))>
+          <!-- user section -->
+            <default-theme-site-menu-section
+            tag="nav"
+            block-name=blockName
+            items=site.getAsArray("navigation.desktopMenu.user")
+            modifiers=["user"]
+            reg-enabled=regEnabled
+            has-user=hasUser
+          />
+        </if>
         <!-- social -->
         <social-icons block-name=blockName />
         <!-- about section -->
@@ -33,19 +45,6 @@ $ const hasUser = defaultValue(input.hasUser, false);
           reg-enabled=regEnabled
           has-user=hasUser
         />
-        <!-- user section || IDX_NAV_ENABLE -->
-        <if(site.getAsArray("navigation.desktopMenu.user"))>
-          <!-- user section -->
-            <default-theme-site-menu-section
-            tag="nav"
-            block-name=blockName
-            label="User"
-            items=site.getAsArray("navigation.desktopMenu.user")
-            modifiers=["secondary"]
-            reg-enabled=regEnabled
-            has-user=hasUser
-          />
-        </if>
       </div>
       <div class="col-6 col-md-4 col-lg-3">
         <!-- sections -->
@@ -69,6 +68,18 @@ $ const hasUser = defaultValue(input.hasUser, false);
   <marko-web-element block-name=blockName name="contents-mobile">
     <!-- search box -->
     <search block-name=blockName />
+    <!-- user section || IDX_NAV_ENABLE -->
+    <if(site.getAsArray("navigation.mobileMenu.user"))>
+      <!-- user section -->
+        <default-theme-site-menu-section
+        tag="nav"
+        block-name=blockName
+        items=site.getAsArray("navigation.mobileMenu.user")
+        modifiers=["user"]
+        reg-enabled=regEnabled
+        has-user=hasUser
+      />
+    </if>
     <!-- social -->
     <social-icons block-name=blockName />
     <!-- primary section -->

--- a/packages/theme-monorail/scss/components/_site-menu.scss
+++ b/packages/theme-monorail/scss/components/_site-menu.scss
@@ -161,6 +161,16 @@ body.site-menu--open {
         }
       }
     }
+    &--user {
+      padding-bottom: 4px;
+      margin-bottom: $theme-site-navbar-menu-link-padding-x + 4px;
+      border-bottom: 1px solid $gray-200;
+      #{ $self }__link {
+        padding-top: 10px;
+        padding-bottom: 10px;
+        @include skin-typography($style: "menu-item-secondary-header");
+      }
+    }
   }
 }
 

--- a/sites/overdriveonline.com/config/navigation.js
+++ b/sites/overdriveonline.com/config/navigation.js
@@ -29,6 +29,7 @@ const utilities = [
 ];
 
 const mobileMenu = {
+  user: [],
   primary: [
     ...topics.primary,
     ...topics.expanded,


### PR DESCRIPTION
 - Add user links to Desktop & Mobile drop down menus.
 - Update config to only display Sign Up vs Log In & Register.
 - Update labels to Sign Up, Sign Out & Manage Account vs Log In, Register, My Account & Log Out

### Desktop: 
<img width="1191" alt="Screen Shot 2022-04-11 at 11 08 09 AM" src="https://user-images.githubusercontent.com/3845869/162784525-eee91f46-a730-44d1-a487-d89e1e8754d1.png">
<img width="1193" alt="Screen Shot 2022-04-11 at 11 08 51 AM" src="https://user-images.githubusercontent.com/3845869/162784537-f54901ec-e0d5-4d86-b235-13aa8106c7aa.png">

### Mobile: 
<img width="401" alt="Screen Shot 2022-04-11 at 11 09 12 AM" src="https://user-images.githubusercontent.com/3845869/162784637-17ddcc8c-df27-4639-bcb1-54723c991cbe.png">
<img width="407" alt="Screen Shot 2022-04-11 at 11 08 59 AM" src="https://user-images.githubusercontent.com/3845869/162784625-de194c72-1925-49f9-b78f-e868d3fef953.png">



