### PR TITLE
Fix form css targeting when loading in content body

### DIFF
--- a/packages/global/scss/components/user.scss
+++ b/packages/global/scss/components/user.scss
@@ -45,7 +45,8 @@
 
 .page-wrapper {
   &__section {
-    &--user-form{
+    &--user-form,
+    .content-page-gate {
       .address-block {
         > legend {
           display: none;


### PR DESCRIPTION
<img width="819" alt="Screen Shot 2022-04-20 at 8 35 49 AM" src="https://user-images.githubusercontent.com/3845869/164242852-009b7e16-0902-4976-b04c-8538ad883222.png">
