### PR TITLE
Use login route vs register route when user logged-out

### DIFF
--- a/packages/global/config/identity-x-nav.js
+++ b/packages/global/config/identity-x-nav.js
@@ -11,12 +11,12 @@ module.exports = ({ site }) => {
   ];
   const targets = site.getAsArray('idxNavItems.navigationTargets').length ? site.getAsArray('idxNavItems.navigationTargets') : defaultTargets;
   const navConfig = [
-    // {
-    //   href: idxConfig.getEndpointFor('login'),
-    //   label: 'Log In',
-    //   when: 'logged-out',
-    //   modifiers: ['user'],
-    // },
+    {
+      href: idxConfig.getEndpointFor('login'),
+      label: 'Sign In',
+      when: 'logged-out',
+      modifiers: ['user'],
+    },
     {
       href: idxConfig.getEndpointFor('profile'),
       label: 'Manage Account',
@@ -29,12 +29,12 @@ module.exports = ({ site }) => {
       when: 'logged-in',
       modifiers: ['user'],
     },
-    {
-      href: idxConfig.getEndpointFor('register'),
-      label: 'Sign Up',
-      when: 'logged-out',
-      modifiers: ['user'],
-    },
+    // {
+    //   href: idxConfig.getEndpointFor('register'),
+    //   label: 'Sign Up',
+    //   when: 'logged-out',
+    //   modifiers: ['user'],
+    // },
   ];
   targets.forEach((target) => {
     const nav = site.get(target);

--- a/packages/theme-monorail/components/site-menu/index.marko
+++ b/packages/theme-monorail/components/site-menu/index.marko
@@ -27,6 +27,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
             <default-theme-site-menu-section
             tag="nav"
             block-name=blockName
+            label="Account"
             items=site.getAsArray("navigation.desktopMenu.user")
             modifiers=["user"]
             reg-enabled=regEnabled
@@ -74,6 +75,7 @@ $ const hasUser = defaultValue(input.hasUser, false);
         <default-theme-site-menu-section
         tag="nav"
         block-name=blockName
+        label="Account"
         items=site.getAsArray("navigation.mobileMenu.user")
         modifiers=["user"]
         reg-enabled=regEnabled

--- a/packages/theme-monorail/scss/components/_site-menu.scss
+++ b/packages/theme-monorail/scss/components/_site-menu.scss
@@ -162,13 +162,37 @@ body.site-menu--open {
       }
     }
     &--user {
+      padding-top: 0;
       padding-bottom: 4px;
-      margin-bottom: $theme-site-navbar-menu-link-padding-x + 4px;
+      margin-bottom: 12px;
       border-bottom: 1px solid $gray-200;
-      #{ $self }__link {
-        padding-top: 10px;
-        padding-bottom: 10px;
-        @include skin-typography($style: "menu-item-secondary-header");
+
+      #{ $self } {
+        &__header {
+          @include skin-typography($style: "menu-item-secondary-header");
+          margin-bottom: 6px;
+        }
+
+        &__item {
+          @include skin-typography($style: "menu-item-secondary");
+          @media (min-width: $skin-desktop-menu-breakpoint) {
+            font-size: 18px;
+            font-weight: $font-weight-normal;
+          }
+        }
+
+        &__link {
+          @include skin-typography-link($style: "menu-item-secondary", $link-style: "primary");
+          @media (min-width: $skin-desktop-menu-breakpoint) {
+            padding-top: 10px;
+            padding-bottom: 10px;
+          }
+          &--active {
+            // stylelint-disable-next-line
+            font-weight: skin-typography-prop("menu-item-secondary", "font-weight");
+            color: skin-typography-link-prop("menu-item-secondary", "primary", "hover-color");
+          }
+        }
       }
     }
   }

--- a/packages/theme-monorail/scss/components/_site-menu.scss
+++ b/packages/theme-monorail/scss/components/_site-menu.scss
@@ -170,6 +170,7 @@ body.site-menu--open {
       #{ $self } {
         &__header {
           @include skin-typography($style: "menu-item-secondary-header");
+          background-color: transparent;
           margin-bottom: 6px;
         }
 


### PR DESCRIPTION
Display login link `Sign In` vs the register link to display in navigation.

### Desktop:
<img width="1291" alt="Screen Shot 2022-04-29 at 8 03 19 AM" src="https://user-images.githubusercontent.com/3845869/165950369-669639d0-d923-4f93-8689-4b485c213674.png">
<img width="1291" alt="Screen Shot 2022-04-29 at 8 04 06 AM" src="https://user-images.githubusercontent.com/3845869/165950398-2e7e97e5-865b-41f2-b8aa-3d68093b6da2.png">


### Mobile:

<img width="400" alt="Screen Shot 2022-04-29 at 8 11 36 AM" src="https://user-images.githubusercontent.com/3845869/165951171-11775793-2076-41b4-a2df-9135a21bd03d.png">
<img width="397" alt="Screen Shot 2022-04-29 at 8 12 13 AM" src="https://user-images.githubusercontent.com/3845869/165951180-6a2e948d-778b-45c3-b6e8-ab54859f82d2.png">

