### PR TITLE
Remove direct page inclusion of reCAPTCHA

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -106,15 +106,6 @@ $ const { gamDefer, gtmDefer } = req.query;
     <theme-site-footer />
   </@below-container>
   <@below-wrapper>
-  $ const { recaptcha } = out.global;
-    <if(recaptcha && recaptcha.siteKey)>
-      <marko-web-deferred-script-loader-register
-        name='recaptcha'
-        on="load"
-        src=`https://www.google.com/recaptcha/api.js?render=${recaptcha.siteKey}`
-        request-frame=true
-      />
-    </if>
     <marko-web-deferred-script-loader-load />
   </@below-wrapper>
 </marko-web-document>


### PR DESCRIPTION
@TODO: @parameter1/base-cms-marko-web-theme-monorail pacakge once approved, merged & released.

https://github.com/parameter1/base-cms/pull/309

The above will move the inclusion of the reCAPTCHA script to submit action of the two step1.vue component in the newsletter sign up functionality that utilizes this script.