### PR TITLE
Add aria-labelled region to Content Meter.

### DIFF
--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -38,7 +38,7 @@ $ const classes = [
   <if(displayGate && displayOverlay)>
     <div class="content-meter__overlay"/>
   </if>
-  <div class="content-meter__bar">
+  <div class="content-meter__bar" role="region" aria-label="Content Meter">
     <global-content-meter-track />
     <div class="content-meter__title">
       <theme-menu-toggle-button


### PR DESCRIPTION
PROD:
![Prod-Menu-Toggle](https://user-images.githubusercontent.com/46794001/172709429-611bd862-2c6d-4c8e-919a-91c2a2d64d92.png)

DEV:
![Dev-Aria-Region](https://user-images.githubusercontent.com/46794001/172709437-3558685a-04f3-4793-96a3-d4b5a02dd94a.png)

(Dev includes changes made in: https://github.com/parameter1/base-cms/pull/329 but those are not required by this PR)
