### PR TITLE
Replace ‘Gear’ block with ‘Market Pulse’

### DIFF
--- a/sites/equipmentworld.com/server/templates/index.marko
+++ b/sites/equipmentworld.com/server/templates/index.marko
@@ -62,7 +62,7 @@ $ const { id, alias, name, pageNode } = input;
   </@section>
 
   <@section>
-    <theme-products-block alias="gear" default-description="Cool stuff for contractors" />
+    <theme-products-block alias="market-pulse" default-description="News & views on where the industry is headed" />
   </@section>
 
   <@section>


### PR DESCRIPTION
<img width="1152" alt="Screen Shot 2022-06-29 at 7 40 42 AM" src="https://user-images.githubusercontent.com/64623209/176438715-5df62a04-c647-45bb-8eb3-6d2683c84f7e.png">
