### PR TITLE
Bypass nomination pages to support redirection to archive pages.

### DIFF
--- a/sites/truckpartsandservice.com/server/routes/index.js
+++ b/sites/truckpartsandservice.com/server/routes/index.js
@@ -2,7 +2,7 @@ const home = require('./home');
 const content = require('./content');
 const dynamicPages = require('./dynamic-page');
 const websiteSections = require('./website-section');
-const staticPages = require('./static');
+// const staticPages = require('./static');
 
 module.exports = (app) => {
   // Homepage
@@ -15,7 +15,7 @@ module.exports = (app) => {
   content(app);
 
   // Static Pages
-  staticPages(app);
+  // staticPages(app);
 
   // Website Sections
   websiteSections(app);


### PR DESCRIPTION
See: https://github.com/parameter1/randall-reilly-websites/pull/357 and https://github.com/parameter1/randall-reilly-websites/pull/259