### PR TITLE
Add canBeInitiallyExpanded checks to newsletterState & contentMeter middleware

### DIFF
--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -34,38 +34,40 @@ $ const classes = [
   `${(displayGate && displayOverlay) ? "content-meter--display-overlay" : "" }`,
 ].join(" ");
 
-<div class=classes>
-  <if(displayGate && displayOverlay)>
-    <div class="content-meter__overlay"/>
-  </if>
-  <div class="content-meter__bar" role="region" aria-label="Content Meter">
-    <global-content-meter-track />
-    <div class="content-meter__title">
-      <theme-menu-toggle-button
-        class="content-meter__toggler"
-        targets=[
-          ".content-meter"
-        ]
-        beforeExpanded=`${title}`
-        beforeCollapsed=`${collapsedTitle}`
-        toggle-class="content-meter--open"
-        icon-modifiers=["xl"]
-        initially-expanded=true
-        icon-name="chevron-up"
-        expanded-icon-name="chevron-down"
-      />
-    </div>
-    <p class="content-meter__call-to-action">
-      $!{callToAction}
-    </p>
-    <div class="content-meter__body">
-      <div class="content-meter__login-form">
-        <marko-web-identity-x-form-login
-          login-email-placeholder="your@email.com"
-          source="content_meter_login"
-          additional-event-data=additionalEventData
+<if(displayGate)>
+  <div class=classes>
+    <if(displayOverlay)>
+      <div class="content-meter__overlay"/>
+    </if>
+    <div class="content-meter__bar" role="region" aria-label="Content Meter">
+      <global-content-meter-track />
+      <div class="content-meter__title">
+        <theme-menu-toggle-button
+          class="content-meter__toggler"
+          targets=[
+            ".content-meter"
+          ]
+          beforeExpanded=`${title}`
+          beforeCollapsed=`${collapsedTitle}`
+          toggle-class="content-meter--open"
+          icon-modifiers=["xl"]
+          initially-expanded=true
+          icon-name="chevron-up"
+          expanded-icon-name="chevron-down"
         />
+      </div>
+      <p class="content-meter__call-to-action">
+        $!{callToAction}
+      </p>
+      <div class="content-meter__body">
+        <div class="content-meter__login-form">
+          <marko-web-identity-x-form-login
+            login-email-placeholder="your@email.com"
+            source="content_meter_login"
+            additional-event-data=additionalEventData
+          />
+        </div>
       </div>
     </div>
   </div>
-</div>
+</if>

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -64,9 +64,16 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   const idFromQuery = getId(query.oly_enc_id);
   const idFromCookie = cookies.oly_enc_id ? getId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
   const olyEncId = idFromQuery || idFromCookie;
-
+  // Prop to see if the newsletterState is going to attempt to be initiallyExpanded
+  // If it can.  Allow it to win and add prop check to list to disable contentMeter
+  const newsletterCanBeInitiallyExpanded = res.locals.newsletterState.canBeInitiallyExpanded;
   // If disabled, not logged in & have a oly_enc_id or logged in and have all required fields
-  if (!config.enable || (!isLoggedIn && olyEncId) || (isLoggedIn && !requiresUserInput));
+  if (
+    newsletterCanBeInitiallyExpanded
+    || !config.enable
+    || (!isLoggedIn && olyEncId)
+    || (isLoggedIn && !requiresUserInput)
+  );
 
   else if (isLoggedIn && requiresUserInput && await shouldMeter(req)) {
     res.locals.contentMeterState = {

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -68,12 +68,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   // If it can.  Allow it to win and add prop check to list to disable contentMeter
   const newsletterCanBeInitiallyExpanded = res.locals.newsletterState.canBeInitiallyExpanded;
   // If disabled, not logged in & have a oly_enc_id or logged in and have all required fields
-  if (
-    newsletterCanBeInitiallyExpanded
-    || !config.enable
-    || (!isLoggedIn && olyEncId)
-    || (isLoggedIn && !requiresUserInput)
-  );
+  if (!config.enable || (!isLoggedIn && olyEncId) || (isLoggedIn && !requiresUserInput));
 
   else if (isLoggedIn && requiresUserInput && await shouldMeter(req)) {
     res.locals.contentMeterState = {
@@ -97,14 +92,15 @@ module.exports = () => asyncRoute(async (req, res, next) => {
       valid.push({ id, viewed: now });
     }
 
-    const displayGate = (valid.length >= config.viewLimit && !valid.find(v => v.id === id));
+    const displayOverlay = (valid.length >= config.viewLimit && !valid.find(v => v.id === id));
 
     res.locals.contentMeterState = {
       ...config,
       views: valid.length,
       isLoggedIn: false,
       requiresUserInput: true,
-      displayGate,
+      displayGate: (config.enable && !newsletterCanBeInitiallyExpanded),
+      displayOverlay,
     };
     res.cookie(cookieName, JSON.stringify(valid), { maxAge: config.timeframe });
   }

--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -66,7 +66,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   const olyEncId = idFromQuery || idFromCookie;
   // Prop to see if the newsletterState is going to attempt to be initiallyExpanded
   // If it can.  Allow it to win and add prop check to list to disable contentMeter
-  const newsletterCanBeInitiallyExpanded = res.locals.newsletterState.canBeInitiallyExpanded;
+  const pushdownWins = Boolean(get(res.locals.newsletterState.canBeInitiallyExpanded));
   // If disabled, not logged in & have a oly_enc_id or logged in and have all required fields
   if (!config.enable || (!isLoggedIn && olyEncId) || (isLoggedIn && !requiresUserInput));
 
@@ -99,7 +99,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
       views: valid.length,
       isLoggedIn: false,
       requiresUserInput: true,
-      displayGate: (config.enable && !newsletterCanBeInitiallyExpanded),
+      displayGate: (config.enable && !pushdownWins),
       displayOverlay,
     };
     res.cookie(cookieName, JSON.stringify(valid), { maxAge: config.timeframe });

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -23,7 +23,7 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
     fromEmail,
     disabled,
     initiallyExpanded,
-    // set this for other middlewares to now it can be set later
+    // set this for other middlewares to know it can be set later
     // if formatContentResponse conditions are met
     canBeInitiallyExpanded,
     cookie: { name: cookieName, maxAge },

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -7,7 +7,8 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const olyEncId = get(req, 'query.oly_enc_id');
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const initiallyExpanded = (setCookie === true) && !(hasCookie || fromEmail || disabled);
+  const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
+  const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 
   // Expire in 14 days (2yr if already signed up)
   const days = fromEmail ? 365 * 2 : 14;
@@ -22,6 +23,9 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
     fromEmail,
     disabled,
     initiallyExpanded,
+    // set this for other middlewares to now it can be set later
+    // if formatContentResponse conditions are met
+    canBeInitiallyExpanded,
     cookie: { name: cookieName, maxAge },
   };
   next();

--- a/sites/truckpartsandservice.com/server/routes/content.js
+++ b/sites/truckpartsandservice.com/server/routes/content.js
@@ -43,9 +43,10 @@ module.exports = (app) => {
   // determin to use newsletterstate or contentMeter middleware
   routesList.forEach((route) => {
     if (route.withContentMeter && contentMeterEnable) {
-      app.get(route.regex, contentMeter(), withContent({
+      app.get(route.regex, newsletterState({ setCookie: false }), contentMeter(), withContent({
         template: route.template,
         queryFragment: route.queryFragment,
+        formatResponse: formatContentResponse,
       }));
     } else {
       app.get(route.regex, newsletterState({ setCookie: false }), withContent({


### PR DESCRIPTION
add canBeInitiallyExpanded prop within newsletterState that the other middleware, specifically contentMeter, can also handle this condition.  In this case if can be initially expanded assume the newsletter push down, or content gating, will win and disable the contentMeter.  

First page visit:
<img width="1240" alt="Screen Shot 2022-09-16 at 11 10 25 AM" src="https://user-images.githubusercontent.com/3845869/190683112-cb789014-4141-4a35-9193-b9fd09636314.png">

Page refresh(second page visit and pushdown/cookie was already set):
<img width="1167" alt="Screen Shot 2022-09-16 at 11 10 37 AM" src="https://user-images.githubusercontent.com/3845869/190683254-2cf22b1d-8134-45a5-a281-9401bdfe5617.png">
