### PR TITLE
Remove postalCode from requiredServerFields

### DIFF
--- a/packages/global/config/identity-x.js
+++ b/packages/global/config/identity-x.js
@@ -14,7 +14,7 @@ module.exports = ({
     'regionCode',
   ],
   defaultCountryCode = 'US',
-  requiredServerFields = ['organization', 'countryCode', 'postalCode'],
+  requiredServerFields = ['organization', 'countryCode'],
   requiredClientFields = ['organization', 'countryCode', 'postalCode'],
   ...rest
 } = {}) => {


### PR DESCRIPTION
This can only be required on the client side as it depends on the user picking US, Canada or Mexico as their countryCode for this field to display.  If they choose anything else this field is no longer available to the user and can not be required server side.