### PR TITLE
Remove postalCode from list of serverRequiredFields

### DIFF
--- a/packages/global/config/identity-x.js
+++ b/packages/global/config/identity-x.js
@@ -14,7 +14,7 @@ module.exports = ({
     'regionCode',
   ],
   defaultCountryCode = 'US',
-  requiredServerFields = ['organization', 'countryCode', 'postalCode'],
+  requiredServerFields = ['organization', 'countryCode'],
   requiredClientFields = ['organization', 'countryCode', 'postalCode'],
   ...rest
 } = {}) => {

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -8,7 +8,6 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
   const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
-  console.log(canBeInitiallyExpanded);
   const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 
   // Expire in 14 days (2yr if already signed up)


### PR DESCRIPTION
This can only be required on the client side as it depends on the user picking US, Canada or Mexico as their countryCode for this field to display. If they choose anything else this field is no longer available to the user and can not be required server side.