### PR TITLE
Add whitepapers to promo cards

### DIFF
--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -1,6 +1,7 @@
 import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
 import PromoA from "@randall-reilly/package-global/components/blocks/promos/ovd-reader-rigs-submit";
 import PromoB from "@randall-reilly/package-global/components/blocks/ovd-pib-manual-promo";
+import PromoC from "@parameter1/base-cms-marko-web-theme-monorail/components/blocks/white-papers"
 
-$ const PromotionComponent = shuffle([PromoA, PromoB])[0];
+$ const PromotionComponent = shuffle([PromoA, PromoB, PromoC])[0];
 <${PromotionComponent} />


### PR DESCRIPTION
Shows in rotation with previous 2 promo cards:
<img width="1156" alt="Screen Shot 2022-10-03 at 11 55 54 AM" src="https://user-images.githubusercontent.com/64623209/193635172-8e45a39a-40c5-4860-9b2f-e3c8f315904f.png">
<img width="1143" alt="Screen Shot 2022-10-03 at 11 56 01 AM" src="https://user-images.githubusercontent.com/64623209/193635175-fa9c4a1f-7160-4584-97b4-ad8e44c898c7.png">
<img width="1164" alt="Screen Shot 2022-10-03 at 11 56 11 AM" src="https://user-images.githubusercontent.com/64623209/193635178-3a8eab28-4faa-4b53-8a1e-4d3f4168d37e.png">
