### PR TITLE
Add onLoginLinkSentFormatter to adjust promoCode on the payload if user has website product

### DIFF
--- a/packages/global/config/omeda-identity-x.js
+++ b/packages/global/config/omeda-identity-x.js
@@ -131,7 +131,6 @@ module.exports = ({
       const newSubscriptions = productIds.filter(
         id => !subscriptions.some(({ product }) => product.deploymentTypeId === id),
       );
-      console.log(payload);
       if (newSubscriptions) {
         return ({
           ...payload,

--- a/packages/global/config/omeda-identity-x.js
+++ b/packages/global/config/omeda-identity-x.js
@@ -63,7 +63,40 @@ module.exports = ({
   appendPromoCodeToHook,
   appendBehaviorToHook,
   appendDemographicToHook,
+  onLoginLinkSentFormatter: (async ({ req, payload }) => {
+    // const identityXOptInHooks = req.app.locals.site.getAsObject('identityXOptInHooks');
+    const omeda = req.app.locals.site.getAsObject('omeda');
+    const { user } = payload;
 
+    const found = getAsArray(user, 'externalIds')
+      .find(({ identifier, namespace }) => identifier.type === 'encrypted'
+        && namespace.provider === 'omeda'
+        && namespace.tenant === omeda.brandKey);
+
+    // BAIL if no encryptedCustomerId and return payload
+    if (!found) return payload;
+    const encryptedCustomerId = get(found, 'identifier.value');
+
+    // Retrive the omeda customer
+    const omedaCustomer = await getOmedaCustomerRecord({
+      omedaGraphQLClient: req.$omedaGraphQLClient,
+      encryptedCustomerId,
+    });
+    const subscriptions = getAsArray(omedaCustomer, 'subscriptions');
+    const hasWebsiteSubscription = subscriptions.find(({ product }) => product.type.id === 'WEBSITE' && product.id === rapidIdentProductId);
+    // If the user already has the website product do
+    // return payload with registration_meter promo code ref removed
+    if (hasWebsiteSubscription && (payload.promoCode || payload.appendPromoCodes.length)) {
+      const promoCode = !payload.promoCode.includes('registration_meter') ? payload.promoCode : undefined;
+      const appendPromoCodes = payload.appendPromoCodes.filter(code => !code.includes('registration_meter'));
+      return {
+        ...payload,
+        promoCode,
+        appendPromoCodes,
+      };
+    }
+    return payload;
+  }),
   onAuthenticationSuccessFormatter: (async ({ req, payload }) => {
     // BAIL if omedaGraphQLCLient isnt available return payload.
     if (!req.$omedaGraphQLClient) return payload;
@@ -92,9 +125,11 @@ module.exports = ({
       const subscriptions = getAsArray(omedaCustomer, 'subscriptions');
       // For each autoOptinProduct check if they have a subscription.
       // Sign the user up if they do not
+
       const newSubscriptions = productIds.filter(
         id => !subscriptions.some(({ product }) => product.deploymentTypeId === id),
       );
+      console.log(payload);
       if (newSubscriptions) {
         return ({
           ...payload,

--- a/packages/global/config/omeda-identity-x.js
+++ b/packages/global/config/omeda-identity-x.js
@@ -83,7 +83,9 @@ module.exports = ({
       encryptedCustomerId,
     });
     const subscriptions = getAsArray(omedaCustomer, 'subscriptions');
-    const hasWebsiteSubscription = subscriptions.find(({ product }) => product.type.id === 'WEBSITE' && product.id === rapidIdentProductId);
+    const hasWebsiteSubscription = subscriptions.find(({
+      product,
+    }) => product.id === rapidIdentProductId);
     // If the user already has the website product do
     // return payload with registration_meter promo code ref removed
     if (hasWebsiteSubscription && (payload.promoCode || payload.appendPromoCodes.length)) {

--- a/sites/ccjdigital.com/config/content-meter.js
+++ b/sites/ccjdigital.com/config/content-meter.js
@@ -2,5 +2,6 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'CCJ_registration_meter',
   enable: true,
 };

--- a/sites/equipmentworld.com/config/content-meter.js
+++ b/sites/equipmentworld.com/config/content-meter.js
@@ -2,5 +2,6 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'EQW_registration_meter',
   enable: true,
 };

--- a/sites/hardworkingtrucks.com/config/content-meter.js
+++ b/sites/hardworkingtrucks.com/config/content-meter.js
@@ -2,4 +2,5 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'HWT_registration_meter',
 };

--- a/sites/overdriveonline.com/config/content-meter.js
+++ b/sites/overdriveonline.com/config/content-meter.js
@@ -2,5 +2,6 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'OV_registration_meter',
   enable: true,
 };

--- a/sites/totallandscapecare.com/config/content-meter.js
+++ b/sites/totallandscapecare.com/config/content-meter.js
@@ -2,4 +2,5 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'TLC_registration_meter',
 };

--- a/sites/truckersnews.com/config/content-meter.js
+++ b/sites/truckersnews.com/config/content-meter.js
@@ -2,4 +2,5 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'TN_registration_meter',
 };

--- a/sites/truckpartsandservice.com/config/content-meter.js
+++ b/sites/truckpartsandservice.com/config/content-meter.js
@@ -2,5 +2,6 @@ const defaultConfig = require('@randall-reilly/package-global/config/content-met
 
 module.exports = {
   ...defaultConfig,
+  promoCode: 'TPS_registration_meter',
   enable: true,
 };


### PR DESCRIPTION
Add onLoginLinkSentFormatter that will check to see if the current user has the subscription to the current website product.  If it does assume the user has already been through this process and do not resubmit the promoCode for registration_meter, or reset the promoCode to undefined.  

Also add/ensure the promoCodes are set for the site not currently using the contentMeter.

**Example:**
First time visiting TPS.  I click a piece of content and fill in the content meter.  The payload is not modified as there is no omedaCustomerRecord yet.  so it send the email address and the promoCode as expected.  The user then has to click the link and file out their profile.  On authenticationSuccess the user is auto signed up to the daily.  

I then logout.  Come back and fill out the content meter again.  It now will remove the preset registreation_meter promoCode on loginLinkSent and the user goes along the login process as normal. However on authenticateSuccess it will also not sign them up  for the newsletter again.

