### PR TITLE
Add onUserProfileUpdateFormatter for checking/setting of a profile demographics

### DIFF
--- a/sites/ccjdigital.com/config/identity-x-opt-in-hooks.js
+++ b/sites/ccjdigital.com/config/identity-x-opt-in-hooks.js
@@ -3,4 +3,10 @@ module.exports = {
     productIds: [29],
     promoCode: 'CCJ_registration_meter',
   },
+  onUserProfileUpdate: {
+    appendDemographics: [
+      { demographicId: 1482, valueIds: [5138] },
+    ],
+    promoCode: 'EQW_Profile Updated_Meter',
+  },
 };

--- a/sites/equipmentworld.com/config/identity-x-opt-in-hooks.js
+++ b/sites/equipmentworld.com/config/identity-x-opt-in-hooks.js
@@ -3,4 +3,10 @@ module.exports = {
     productIds: [22],
     promoCode: 'EQW_registration_meter',
   },
+  onUserProfileUpdate: {
+    appendDemographics: [
+      { demographicId: 1481, valueIds: [5134] },
+    ],
+    promoCode: 'EQW_Profile Updated_Meter',
+  },
 };

--- a/sites/overdriveonline.com/config/identity-x-opt-in-hooks.js
+++ b/sites/overdriveonline.com/config/identity-x-opt-in-hooks.js
@@ -3,4 +3,10 @@ module.exports = {
     productIds: [33],
     promoCode: 'OV_registration_meter',
   },
+  onUserProfileUpdate: {
+    appendDemographics: [
+      { demographicId: 1480, valueIds: [5132] },
+    ],
+    promoCode: 'OV_Profile Updated_Meter',
+  },
 };

--- a/sites/truckpartsandservice.com/config/identity-x-opt-in-hooks.js
+++ b/sites/truckpartsandservice.com/config/identity-x-opt-in-hooks.js
@@ -3,4 +3,10 @@ module.exports = {
     productIds: [13],
     promoCode: 'TPS_registration_meter',
   },
+  onUserProfileUpdate: {
+    appendDemographics: [
+      { demographicId: 1483, valueIds: [5142] },
+    ],
+    promoCode: 'TPS_Profile Updated_Meter',
+  },
 };


### PR DESCRIPTION
Add the `${pubCode} _profile_updated_meter` promoCode & corisponding demo onUserProfileUpdate step of registration.  Meaning if the given demo doesnt exists added it and set the promoCode.  At this point if the demo does exists do nothing, but I am guessing this will change.