### PR TITLE
Always set demo on user profile updated

### DIFF
--- a/packages/global/config/omeda-identity-x.js
+++ b/packages/global/config/omeda-identity-x.js
@@ -169,23 +169,39 @@ module.exports = ({
         omedaGraphQLClient: req.$omedaGraphQLClient,
         encryptedCustomerId,
       });
-      // Get the current user subscriptions
-      const demographics = getAsArray(omedaCustomer, 'demographics');
 
-      // If the user profile completed demo for this doesnt exists, set it.
-      const demosToAppend = appendDemographics.filter(({
-        demographicId,
-      }) => !demographics.find(({ demographic }) => demographic.id === demographicId));
-      if (demosToAppend && demosToAppend.length) {
+      // Always apply the ${pubcod_Profile Updated_Meter} promocode & Demo
+      if (omedaCustomer && appendDemographics && appendDemographics.length) {
         return ({
           ...payload,
-          appendDemographics: demosToAppend,
+          appendDemographics,
           promoCode,
           appendPromoCodes: [
             { promoCode },
           ],
         });
       }
+
+      // ###### CONDITIONALLY ADD PROMO DEMO WHEN NOT ALREADY SET ##### //
+      // // Get the current user subscriptions
+      // const demographics = getAsArray(omedaCustomer, 'demographics');
+
+      // // If the user profile completed demo for this doesnt exists, set it.
+      // const demosToAppend = appendDemographics.filter(({
+      //   demographicId,
+      // }) => !demographics.find(({ demographic }) => demographic.id === demographicId));
+      // if (demosToAppend && demosToAppend.length) {
+      //   return ({
+      //     ...payload,
+      //     appendDemographics: demosToAppend,
+      //     promoCode,
+      //     appendPromoCodes: [
+      //       { promoCode },
+      //     ],
+      //   });
+      // }
+      // ###### CONDITIONALLY ADD PROMO DEMO WHEN NOT ALREADY SET ##### //
+
 
       // This is for second part of onUserProfileUpdate, but now 100% sure
       // on how omeda intends on handeling this, so waiting for now

--- a/sites/ccjdigital.com/config/identity-x-opt-in-hooks.js
+++ b/sites/ccjdigital.com/config/identity-x-opt-in-hooks.js
@@ -7,6 +7,6 @@ module.exports = {
     appendDemographics: [
       { demographicId: 1482, valueIds: [5138] },
     ],
-    promoCode: 'EQW_Profile Updated_Meter',
+    promoCode: 'CCJ_Profile Updated_Meter',
   },
 };


### PR DESCRIPTION
Change the onUserProfileUpdatedFormatter to always set the profile verification demo & promo code on ever UserProfileUpdate instead of only when it doesn't exist.  

Example payload to rapidIdent:
```js
{ 
  productId: 20,
  email: 'brian@parameter1.com',
  companyName: 'Parameter1',
  title: 'Dev',
  countryCode: 'AUT',
  demographics: [ 
    { id: 72, values: [Array] },
    { id: 1482, values: [Array] }
  ],
  behaviors: [ { id: 89, attributes: [Array] } ],
  promoCode: 'EQW_Profile Updated_Meter'
}
```