### PR TITLE
Ensure there are new subscriptions before modifying the payload onAuthenticationSucess

### DIFF
--- a/packages/global/config/omeda-identity-x.js
+++ b/packages/global/config/omeda-identity-x.js
@@ -131,7 +131,7 @@ module.exports = ({
       const newSubscriptions = productIds.filter(
         id => !subscriptions.some(({ product }) => product.deploymentTypeId === id),
       );
-      if (newSubscriptions) {
+      if (newSubscriptions && newSubscriptions.length) {
         const deploymentTypes = newSubscriptions.map(id => ({ id, optedIn: true }));
         return ({
           ...payload,


### PR DESCRIPTION
When we are modifying the payload onAuthenticationSuccess ensure there are newSubscriptions with a array.length check