### PR TITLE
Add new transcript field to default content layout

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -66,6 +66,11 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           <if(content.embedCode)>
             $ const iframeContent = contentIframe(content);
             <marko-web-content-embed-code block-name=blockName obj=iframeContent />
+            <if(content.transcript)>
+              <marko-web-link href=`#transcript-${id}` class="btn btn-transcript mt-block" title="Transcript">
+                <marko-web-icon name="file" modifiers=["lg"] /> Transcript
+              </marko-web-link>
+            </if>
           </if>
           <else-if(type === "media-gallery")>
             <!-- <marko-web-image-slider images=images /> -->
@@ -128,12 +133,11 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           <else>
 
             $ const bodyId = `content-body-${content.id}`;
-
             <if(shouldInjectAds)>
-              $ const desktopCounts = [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500];
-              $ const mobileCounts = [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250];
+              $ const desktopBodyCounts = [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500];
+              $ const mobileBodyCounts = [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250];
               <theme-gam-inject-ads selector=`#${bodyId}` detect-embeds=true>
-                <for|char| of=desktopCounts>
+                <for|char| of=desktopBodyCounts>
                   <!-- desktop/tablet only -->
                   <@inject
                     at=char
@@ -152,7 +156,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                   modifiers=["max-width-970", "margin-auto-x", "inline-content"]
                 />
 
-                <for|char| of=mobileCounts>
+                <for|char| of=mobileBodyCounts>
                   <!-- mobile only -->
                   <@inject
                     at=char
@@ -163,10 +167,44 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                 </for>
               </theme-gam-inject-ads>
             </if>
-
             <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } >
               <@embed-options lazyloadImages=false/>
             </marko-web-content-body>
+
+            $ const transcriptId = `content-transcript-${content.id}`;
+            <if(shouldInjectAds && content.transcript)>
+              $ const desktopTranscriptCounts = [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500];
+              $ const mobileTranscriptCounts = [250, 900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250];
+              <theme-gam-inject-ads selector=`#${transcriptId}` detect-embeds=true>
+                <for|char| of=desktopTranscriptCounts>
+                  <!-- desktop/tablet only -->
+                  <@inject
+                    at=char
+                    name="inline-content-desktop"
+                    aliases=aliases
+                    modifiers=["max-width-970", "margin-auto-x", "inline-content"]
+                  />
+                </for>
+                <for|char| of=mobileTranscriptCounts>
+                  <!-- mobile only -->
+                  <@inject
+                    at=char
+                    name="inline-content-mobile"
+                    aliases=aliases
+                    modifiers=["max-width-970", "margin-auto-x", "inline-content"]
+                  />
+                </for>
+              </theme-gam-inject-ads>
+            </if>
+            <!-- Add Transcripts and allow for the ad injection -->
+            <if(content.transcript)>
+              <div id=`transcript-${id}` class="page-contents__content-transcript">
+                <marko-web-element block-name="page-contents" name="content-transcript-title">
+                  <marko-web-icon name="file" modifiers=["lg"] /> Transcript
+                </marko-web-element>
+                <marko-web-content-transcript obj=content block-name=blockName attrs={ id: transcriptId }  />
+              </div>
+            </if>
 
             <!-- needs input -->
             <if(input.afterBody)>


### PR DESCRIPTION
This will require the following PRs to be merged and deployed with a dep upgrade.
 - https://github.com/parameter1/base-cms/pull/485
 This will have to be merged and deployed for the new transcript field to appear in management 
  - https://github.com/parameter1/base-platform/pull/183

This PR will:
 - Add jumplink/anchor tag for transcript that sits below the embeded(this will only happen on videos)
 - Add Transcript field a the bottom of content pages when present
 
<img width="1015" alt="Screen Shot 2022-11-10 at 10 34 59 AM" src="https://user-images.githubusercontent.com/3845869/201153509-2a2385d8-8a14-40a7-ae6e-9db3ae45ebdc.png">
<img width="533" alt="Screen Shot 2022-11-10 at 10 35 09 AM" src="https://user-images.githubusercontent.com/3845869/201153511-a5e981c0-bd28-4a24-92fc-96b51fc00eba.png">


 
![ovd-transcript](https://user-images.githubusercontent.com/3845869/201143503-c61c9f59-37ba-4479-9016-052f14a8b96c.jpg)
![ovd-podcast](https://user-images.githubusercontent.com/3845869/201143742-cd3e2e08-59f4-4b42-b2b3-a258aec44fca.jpg)
