### PR TITLE
Make oneTrust static pages support multiple div ids

### DIFF
--- a/packages/global/routes/static-page.js
+++ b/packages/global/routes/static-page.js
@@ -4,8 +4,10 @@ module.exports = (app) => {
   const oneTrust = app.locals.site.getAsArray('oneTrust');
 
   oneTrust.forEach((item) => {
-    if (item.path && item.id) {
-      app.get(item.path, (_, res) => { res.marko(oneTrustTemplate, { oneTrustId: item.id }); });
+    if (item.path && item.oneTrustIds) {
+      app.get(item.path, (_, res) => {
+        res.marko(oneTrustTemplate, { oneTrustIds: item.oneTrustIds });
+      });
     }
   });
 };

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -266,3 +266,7 @@ label {
     }
   }
 }
+
+.otnotice ~ .otnotice {
+  border-top: 5px solid $gray-800;
+}

--- a/packages/global/templates/static/one-trust.marko
+++ b/packages/global/templates/static/one-trust.marko
@@ -24,15 +24,19 @@ $ const description = "";
         />
       </@section>
       <@section>
-        $ const { oneTrustId } = data;
-        $ const oneTrustURL = `https://appds8093.blob.core.windows.net/49a9a972-547e-4c49-b23c-4cc77554cacb/privacy-notices/${oneTrustId}.json`;
-        <div id=`otnotice-${oneTrustId}` class="otnotice mt-4"></div>
-        <script>
-          // To ensure external settings are loaded, use the Initialized promise:
-          OneTrust.NoticeApi.Initialized.then(function() {
-            OneTrust.NoticeApi.LoadNotices(['${oneTrustURL}']);
-          });
-        </script>
+        $ const { oneTrustIds } = data;
+        <if(oneTrustIds)>
+          <for|oneTrustId| of=oneTrustIds>
+            $ const oneTrustURL = `https://appds8093.blob.core.windows.net/49a9a972-547e-4c49-b23c-4cc77554cacb/privacy-notices/${oneTrustId}.json`;
+            <div id=`otnotice-${oneTrustId}` class="otnotice mt-4"></div>
+            <script>
+              // To ensure external settings are loaded, use the Initialized promise:
+              OneTrust.NoticeApi.Initialized.then(function() {
+                OneTrust.NoticeApi.LoadNotices(['${oneTrustURL}']);
+              });
+            </script>
+          </for>
+        </if>
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/sites/equipmentworld.com/config/site.js
+++ b/sites/equipmentworld.com/config/site.js
@@ -65,8 +65,14 @@ module.exports = {
     id: '9e5417f72997170d6',
   },
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: 'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-WBB7QN7',

--- a/sites/hardworkingtrucks.com/config/site.js
+++ b/sites/hardworkingtrucks.com/config/site.js
@@ -65,8 +65,14 @@ module.exports = {
     id: '14c37f5dc982aa830',
   },
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: 'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-KN35FTZ',

--- a/sites/overdriveonline.com/config/site.js
+++ b/sites/overdriveonline.com/config/site.js
@@ -72,8 +72,14 @@ module.exports = {
     { label: 'Soundcloud', href: 'https://soundcloud.com/overdriveradio' },
   ],
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-NDC3FQX',

--- a/sites/totallandscapecare.com/config/site.js
+++ b/sites/totallandscapecare.com/config/site.js
@@ -66,8 +66,14 @@ module.exports = {
     id: '2ffbde674775e605d',
   },
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: 'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-TQW695L',

--- a/sites/truckersnews.com/config/site.js
+++ b/sites/truckersnews.com/config/site.js
@@ -64,8 +64,14 @@ module.exports = {
     id: 'cf19a2a833a06d9d4',
   },
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: 'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-KKR45JP',

--- a/sites/truckpartsandservice.com/config/site.js
+++ b/sites/truckpartsandservice.com/config/site.js
@@ -65,8 +65,14 @@ module.exports = {
     id: '281101e8295e963ba',
   },
   oneTrust: [
-    { path: '/collection', id: 'c04235aa-e9e0-4ff9-b558-5e21aa892d20' },
-    { path: '/termsandprivacy', id: 'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c' },
+    { path: '/collection', oneTrustIds: ['c04235aa-e9e0-4ff9-b558-5e21aa892d20'] },
+    {
+      path: '/termsandprivacy',
+      oneTrustIds: [
+        'd8f2d6c5-d9af-4d60-a93f-7441ca9ad94c',
+        '45d9b939-c3de-4b71-8cbf-e2ffe621ff9c',
+      ],
+    },
   ],
   gtm: {
     containerId: 'GTM-MWZ279J',


### PR DESCRIPTION
convert the static page logic to support passing in multiple oneTrustIds and looping over them to create the target div and script includes.

<img width="1122" alt="Screen Shot 2023-02-03 at 10 12 01 AM" src="https://user-images.githubusercontent.com/3845869/216651926-ce02497b-9704-4e3a-8b50-7c7601816a36.png">
