### PR TITLE
Prevents  content meter display when user agent's browser is Facebook

### DIFF
--- a/packages/global/middleware/content-meter.js
+++ b/packages/global/middleware/content-meter.js
@@ -1,3 +1,4 @@
+const parser = require('ua-parser-js');
 const { get } = require('@parameter1/base-cms-object-path');
 const defaultValue = require('@parameter1/base-cms-marko-core/utils/default-value');
 
@@ -12,6 +13,10 @@ const now = new Date().getTime();
 async function shouldMeter(req) {
   const { apollo, params } = req;
   const config = req.app.locals.site.getAsObject('contentMeter');
+
+  // If broserser Facebook do not display content meter gate.
+  if (parser(req.headers['user-agent']).browser.name === 'Facebook') return false;
+
   const { id } = params;
   const additionalInput = buildContentInput({ req });
   const content = await loader(apollo, { id, additionalInput, queryFragment });

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -45,6 +45,7 @@
     "newrelic": "^6.4.1",
     "node-fetch": "^2.6.1",
     "object-path": "^0.11.5",
-    "slug": "^4.0.2"
+    "slug": "^4.0.2",
+    "ua-parser-js": "^1.0.33"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13140,6 +13140,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+ua-parser-js@^1.0.33:
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.33.tgz#f21f01233e90e7ed0f059ceab46eb190ff17f8f4"
+  integrity sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==
+
 uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"


### PR DESCRIPTION
Add a user agent check for user-agent having a browser.name === ‘Facebook’ to prevent the content meter from showing.


I test by setting the user agent to `'Mozilla/5.0 (iPhone; CPU iPhone OS 14_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/14.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5]',`  vs the standard `req.headers['user-agent']`

