### PR TITLE
Send oly_(eny/anon)_id to GTM

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -10,6 +10,18 @@ $ const {
   contentMeterState,
 } = out.global;
 
+$ const { cookies } = req;
+$ const getCookieId = (value, type) => {
+  if (!value) return null;
+  const trimmed = `${value.replace(/^"/, '').replace(/"$/, '')}`.trim();
+  if (type === 'anon') {
+    return /^[a-z0-9-]{36}$/i.test(trimmed) ? trimmed : null;
+  }
+  if(type === 'enc') {
+    return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
+  }
+  return null;
+};
 $ const omedaConfig = site.get('omeda');
 
 $ const { gamDefer, gtmDefer } = req.query;
@@ -78,6 +90,17 @@ $ const { gamDefer, gtmDefer } = req.query;
         <marko-web-gtm-push data={ user_id: user.id } />
       </if>
     </marko-web-identity-x-context>
+
+    <!-- Send Encrypted Omeda Id to GTM -->
+    $ const oylEncId = cookies.oly_enc_id ? getCookieId(cookies.oly_enc_id, 'enc') : undefined;
+    <if(oylEncId)>
+      <marko-web-gtm-push data={ oly_enc_id: oylEncId } />
+    </if>
+    <!-- Send Anonomouse Omeda Id to GTM -->
+    $ const oylAnonId = cookies.oly_anon_id ? getCookieId(cookies.oly_anon_id, 'anon') : undefined;
+    <if(oylAnonId)>
+      <marko-web-gtm-push data={ oly_anon_id: oylAnonId } />
+    </if>
 
     <!-- start gtm -->
     <marko-web-gtm-start />


### PR DESCRIPTION
Find, format & vet the omeda oly_anon_id & oly_eny_id from cookies and send along to GTM as well as the idX id  when present.