### PR TITLE
Display `global-sponsors-block` with respective sponsors of Trailblazer Award section page, TPS

### DIFF
--- a/packages/global/components/blocks/sponsors.marko
+++ b/packages/global/components/blocks/sponsors.marko
@@ -17,6 +17,12 @@ $ const sponsorImages = {
     { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/premium2000.png", alt: "Successful Dealer Award Sponsor: Premium2000+" },
     { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/automann.png", alt: "Successful Dealer Award Sponsor: Automann USA"},
   ],
+  "trailblazer-award": [
+    { src: "", alt: "" },
+    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/hendrickson.png", alt: "Trailblazer Award Sponsor: Hendrickson" },
+    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/procede.png", alt: "Trailblazer Award Sponsor: Procede Software" },
+    { src: "", alt: "" },
+  ],
 }
 
 $ const imgixSponsors = [];
@@ -37,15 +43,21 @@ $ if (sponsorImages[alias]) {
     </div>
   </div>
   <div class="row sponsor-logos">
-    <for|image, index| of=imgixSponsors>
-      <div class="col logo logo__sda">
-        <marko-web-img
-          class="img-fluid"
-          alt=`${imgixSponsors[index].alt}`
-          src=`${imgixSponsors[index].src}`
-          srcset=[`${imgixSponsors[index].src}&dpr=2 2x`]
-        />
-      </div>
+    <for|image| of=imgixSponsors>
+      $ const { src, alt } = image;
+      <if(src && alt)>
+        <div class="col logo logo__sda">
+          <marko-web-img
+            class="img-fluid"
+            alt=alt
+            src=src
+            srcset=[`${src}&dpr=2 2x`]
+          />
+        </div>
+      </if>
+      <else>
+        <div class="col" />
+      </else>
     </for>
   </div>
 </div>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -57,8 +57,13 @@ $ const perPage = 18;
       />
     </if>
 
-    <if(['distributor-of-the-year-archive', 'successful-dealer-award-archive'].includes(alias))>
-      <global-sponsors-block alias=alias.replace('-archive', '') />
+    <if([
+        "distributor-of-the-year-archive",
+        "successful-dealer-award-archive",
+        "trailblazer-award-archive",
+        'trailblazer-award',
+      ].includes(alias))>
+      <global-sponsors-block alias=alias.replace("-archive", "") />
     </if>
 
     <theme-section-feed-block alias=alias lazyload=false query-name="website-optioned-content">


### PR DESCRIPTION
Screenshots showing what this looks like at various resolutions:

![Screenshot from 2023-03-17 08-53-10](https://user-images.githubusercontent.com/46794001/225925439-910632a5-a8b8-4a71-9632-52538a28ca21.png)
![Screenshot from 2023-03-17 08-53-31](https://user-images.githubusercontent.com/46794001/225925445-73b583b9-10f0-4d42-a3c7-8c4731000fe6.png)
![Screenshot from 2023-03-17 08-53-44](https://user-images.githubusercontent.com/46794001/225925465-0c9a3958-86b6-42fa-bffd-79b6378bb9a9.png)
![Screenshot from 2023-03-17 08-53-52](https://user-images.githubusercontent.com/46794001/225925468-3e8b4a6e-459e-48eb-b4b2-67f8cb9f7b7d.png)
