### PR TITLE
Adjust ad injection body call with mobile ad property adjustments to fix CLS issue

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -131,15 +131,26 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
             />
           </else-if>
           <else>
-            $ const leaderboardAdName = (GAM.btfLeaderboard) ? "inline-leaderboard-mobile" : "inline-content-mobile";
-            $ const leaderboardModifiers = (GAM.btfLeaderboard) ? ["margin-auto-x",  "inline-content", "inline-leaderboard-mobile"] : ["margin-auto-x",  "inline-content", "inline-mobile"];
+
+            <!-- remove the Desktop Leaderboard overrides stuff and set the mobile version correctly.
+
+            $ const desktopLeaderboardAdName = (GAM.btfLeaderboard) ? "leaderboard-desktop" : "inline-content-desktop'";
+            $ const desktopLeaderboardModifiers = (GAM.btfLeaderboard) ? ["margin-auto-x",  "inline-content", "inline-leaderboard-desktop"] : ["margin-auto-x",  "inline-content", "inline-desktop"];
+
+            Add the following back to <theme-body-with-injection call to add desktop leaderboard logic.
+            desktop-leaderboard-ad-name=desktopLeaderboardAdName
+            desktop-leaderboard-modifiers=desktopLeaderboardModifiers
+
+            -->
+            $ const mobileLeaderboardAdName = (GAM.btfLeaderboard) ? "inline-leaderboard-mobile" : "inline-content-mobile";
+            $ const mobileLeaderboardModifiers = (GAM.btfLeaderboard) ? ["margin-auto-x",  "inline-content", "inline-leaderboard-mobile"] : ["margin-auto-x",  "inline-content", "inline-mobile"];
             <theme-body-with-injection
               content=content
               aliases=aliases
               block-name=blockName
               preventHTMLInjection=!shouldInjectAds
-              leaderboard-ad-name=leaderboardAdName
-              leaderboard-modifiers=leaderboardModifiers
+              mobile-leaderboard-ad-name=mobileLeaderboardAdName
+              mobile-leaderboard-modifiers=mobileLeaderboardModifiers
               lazyload-first-image=lazyloadFirstImage
             />
             <if(content.transcript)>


### PR DESCRIPTION
Set the mobile-leaderboard-ad-name & mobile-leaderboard-ad-modifiers props according to the config.  This will also adjust and apply the modifiers for INLINE-LEADERBOARD-MOBILE template vs INLINE-CONTENT-MOBILE and apply the css accordingly.  

### Before:
<img width="1202" alt="Screen Shot 2023-04-06 at 10 47 15 AM" src="https://user-images.githubusercontent.com/3845869/230431207-6cc0db77-e035-4811-b231-db2f4a00cdef.png">
### After:
<img width="1181" alt="Screen Shot 2023-04-06 at 10 47 02 AM" src="https://user-images.githubusercontent.com/3845869/230431179-6c23844a-5cae-43e7-b958-642ac7226ac1.png">
