### PR TITLE
Set source and additionalEventData for metered

### DIFF
--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -7,6 +7,7 @@ $ const {
 } = contentMeterState;
 $ const additionalEventData = {
   promoCode: site.get("contentMeter.promoCode", undefined),
+  contentGateType: "metered",
   views,
   viewLimit,
   displayGate,
@@ -64,7 +65,7 @@ $ const classes = [
         <div class="content-meter__login-form">
           <marko-web-identity-x-form-login
             login-email-placeholder="your@email.com"
-            source="content_meter_login"
+            source="contentGate"
             additional-event-data=additionalEventData
           />
         </div>


### PR DESCRIPTION
Correctly set source to contentGate and set contentGateType to metered.  This will map correctly to the corresponding omeda demos/behaviors.

[Monorail version of the change #714](https://github.com/parameter1/base-cms/pull/714)
[IdentityX](https://github.com/parameter1/identity-x/pull/36)

<img width="1030" alt="Screen Shot 2023-06-06 at 11 56 13 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/7f2c683d-b0ea-47d2-b21d-4409ca822190">

@todo Figure out if these demos really need to follow through to auth/profile pages.  At the moment only loginSource does. 
 We would have to ensure both source & contentGateType are passed along when source is contentGate