### PR TITLE
Adjust newsletterState to account for mobile and site level configuration

### DIFF
--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -1,14 +1,25 @@
+const defaultValue = require('@parameter1/base-cms-marko-core/utils/default-value');
 const { get } = require('@parameter1/base-cms-object-path');
 
 const cookieName = 'enlPrompted';
+
 const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
+  // account for site level enabling of initially expanded
+  const newsletterConfig = req.app.locals.site.getAsObject('newsletter');
+  const siteConfigCBIE = defaultValue(newsletterConfig.pushdown.canBeInitiallyExpanded, true);
+
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   // const disabled = get(req, 'query.newsletterDisabled');
   const disabled = true;
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
+  const canBeInitiallyExpanded = !(
+    siteConfigCBIE
+    || hasCookie
+    || fromEmail
+    || disabled
+  );
   const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 
   // Expire in 14 days (2yr if already signed up)

--- a/sites/ccjdigital.com/config/newsletter.js
+++ b/sites/ccjdigital.com/config/newsletter.js
@@ -61,6 +61,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ccj-full.png',
   },
   pushdown: {
+    canBeInitiallyExpanded: false,
     ...defaults,
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ccj-half.png',
     description: 'Join 80,000 trucking professionals who get helpful insights and important news delivered straight to their inbox with the CCJ newsletter.',

--- a/sites/equipmentworld.com/config/newsletter.js
+++ b/sites/equipmentworld.com/config/newsletter.js
@@ -72,6 +72,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/eqw-full.png',
   },
   pushdown: {
+    canBeInitiallyExpanded: false,
     ...defaults,
     description: 'Join 55,000 construction professionals who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Equipment World</span> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/eqw-half.png',

--- a/sites/overdriveonline.com/config/newsletter.js
+++ b/sites/overdriveonline.com/config/newsletter.js
@@ -57,6 +57,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-full.png',
   },
   pushdown: {
+    canBeInitiallyExpanded: false,
     ...defaults,
     description: 'Join 135,000 owner-operators who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Overdrive</span> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-half.png',

--- a/sites/truckpartsandservice.com/config/newsletter.js
+++ b/sites/truckpartsandservice.com/config/newsletter.js
@@ -53,6 +53,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/tps-full.png',
   },
   pushdown: {
+    canBeInitiallyExpanded: false,
     ...defaults,
     description: 'Join 20,000 dealer and aftermarket professionals who get helpful insights and important news delivered straight to their inbox with the <em>Trucks, Parts, Service</em> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/tps-half.png',


### PR DESCRIPTION
Add isMobile check as well as adding the ability to configure the canBeInitiallyExpanded  value per site. 

