### PR TITLE
Adjust newsletter pushdown with site level mobile config

### DIFF
--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -8,7 +8,8 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   // account for site level enabling of initially expanded
   const newsletterConfig = req.app.locals.site.getAsObject('newsletter');
   const { device } = parser(req.headers['user-agent']);
-  const isMobile = device && device.type === 'mobile';
+  const disableMobileCBIE = defaultValue(newsletterConfig.pushdown.disableMobileCBIE, false);
+  const canBeExpandOnMobile = disableMobileCBIE !== false || (!device || device.type !== 'mobile');
   const siteConfigCBIE = defaultValue(newsletterConfig.pushdown.canBeInitiallyExpanded, true);
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
@@ -16,7 +17,7 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
   const canBeInitiallyExpanded = siteConfigCBIE && !(
-    isMobile
+    canBeExpandOnMobile
     || hasCookie
     || fromEmail
     || disabled

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -9,7 +9,7 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const newsletterConfig = req.app.locals.site.getAsObject('newsletter');
   const { device } = parser(req.headers['user-agent']);
   const disableMobileCBIE = defaultValue(newsletterConfig.pushdown.disableMobileCBIE, false);
-  const canBeExpandOnMobile = disableMobileCBIE !== false || (!device || device.type !== 'mobile');
+  const disableExpandOnMobile = disableMobileCBIE && (device && device.type === 'mobile');
   const siteConfigCBIE = defaultValue(newsletterConfig.pushdown.canBeInitiallyExpanded, true);
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
@@ -17,7 +17,7 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
   const canBeInitiallyExpanded = siteConfigCBIE && !(
-    canBeExpandOnMobile
+    disableExpandOnMobile
     || hasCookie
     || fromEmail
     || disabled

--- a/sites/ccjdigital.com/config/newsletter.js
+++ b/sites/ccjdigital.com/config/newsletter.js
@@ -61,6 +61,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ccj-full.png',
   },
   pushdown: {
+    disableMobileCBIE: true,
     ...defaults,
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ccj-half.png',
     description: 'Join 80,000 trucking professionals who get helpful insights and important news delivered straight to their inbox with the CCJ newsletter.',

--- a/sites/equipmentworld.com/config/newsletter.js
+++ b/sites/equipmentworld.com/config/newsletter.js
@@ -72,6 +72,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/eqw-full.png',
   },
   pushdown: {
+    disableMobileCBIE: true,
     ...defaults,
     description: 'Join 55,000 construction professionals who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Equipment World</span> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/eqw-half.png',

--- a/sites/overdriveonline.com/config/newsletter.js
+++ b/sites/overdriveonline.com/config/newsletter.js
@@ -57,6 +57,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-full.png',
   },
   pushdown: {
+    disableMobileCBIE: true,
     ...defaults,
     description: 'Join 135,000 owner-operators who get helpful insights and important news delivered straight to their inbox with the <span class="newsletter-name">Overdrive</span> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-half.png',

--- a/sites/truckpartsandservice.com/config/newsletter.js
+++ b/sites/truckpartsandservice.com/config/newsletter.js
@@ -53,6 +53,7 @@ module.exports = {
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/tps-full.png',
   },
   pushdown: {
+    disableMobileCBIE: true,
     ...defaults,
     description: 'Join 20,000 dealer and aftermarket professionals who get helpful insights and important news delivered straight to their inbox with the <em>Trucks, Parts, Service</em> newsletter.',
     imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/tps-half.png',


### PR DESCRIPTION
Adjust the newsletter middleware and config to be able to enable/disable the pushdown on mobile per site.

`newsletter.pushdown.disableMobileCBIE: true,`

<img width="427" alt="Screen Shot 2023-06-08 at 2 19 25 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/f6c86437-bc68-4f52-bef9-66234b1816d1">

<img width="388" alt="Screen Shot 2023-06-08 at 2 19 35 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/94031cd6-a976-4421-ba46-a1306a033b2c">
