### PR TITLE
Remove custom event emitter for create user and handle within GTM/dataLayer conditions

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,10 +2,15 @@ import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 
 export default (Browser) => {
   const { EventBus } = Browser;
-  EventBus.$on('identity-x-login-link-sent', ({ data, source, additionalEventData }) => {
-    if (additionalEventData.createdNewUser) {
-      const { appUser } = data;
-      const newIdentityXUser = { userId: appUser.id, source };
+  EventBus.$on('identity-x-authenticated', (data) => {
+    const {
+      id,
+      isFirstTimeVerifying,
+      source,
+      additionalEventData,
+    } = data;
+    if (isFirstTimeVerifying) {
+      const newIdentityXUser = { userId: id, source, additionalEventData };
       window.dataLayer.push({ event: 'identity-x-created-new-user', newIdentityXUser });
     }
   });

--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -1,18 +1,5 @@
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 
 export default (Browser) => {
-  const { EventBus } = Browser;
-  EventBus.$on('identity-x-authenticated', (data) => {
-    const {
-      id,
-      isFirstTimeVerifying,
-      source,
-      additionalEventData,
-    } = data;
-    if (isFirstTimeVerifying) {
-      const newIdentityXUser = { userId: id, source, additionalEventData };
-      window.dataLayer.push({ event: 'identity-x-created-new-user', newIdentityXUser });
-    }
-  });
   MonoRail(Browser);
 };


### PR DESCRIPTION
Remove custom event emitter.  Instead utilize the new verifiedCount prop being sent to the dataLayer to conditionally trigger a GA4 event for create new user when event is identity-x-authenticated && identity-x.verifiedCount === 1.

**This will require GTM container updates for all brands**

Requires the following [BASE-CMS](https://github.com/parameter1/base-cms/pull/733) & [IdX](https://github.com/parameter1/identity-x/pull/39) PR and P1 Deps to be upgraded.  

