### PR TITLE
Use 2 column layout for in-body Related Stories block

### DIFF
--- a/packages/global/components/blocks/stories.marko
+++ b/packages/global/components/blocks/stories.marko
@@ -7,15 +7,28 @@ $ const {
 } = input;
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="wrapper">
-    <marko-web-element block-name=blockName name="header">
-      ${title}
-    </marko-web-element>
-    <theme-content-card-deck-col-flow
-      nodes=nodes
-      modifiers=[blockName]
-      ...(withNativeX && { nativeX })
-    >
-      <@node modifiers=[blockName] />
-    </theme-content-card-deck-col-flow>
+  <marko-web-element block-name=blockName name="header">
+    ${title}
+  </marko-web-element>
+  <theme-card-deck-flow
+    cols=2
+    nodes=nodes
+    modifiers=[blockName]
+  >
+    <@slot|{ node }|>
+      <theme-content-node
+        image-position="right"
+        full-height=true
+        card=true
+        flush=false
+        modifiers=[blockName]
+        node=node
+        with-teaser=false
+        with-dates=false
+      >
+        <@image width=112 ar="1:1" />
+      </theme-content-node>
+    </@slot>
+  </theme-card-deck-flow>
   </marko-web-element>
 </marko-web-block>

--- a/packages/global/scss/components/blocks/_inbody-related-stories.scss
+++ b/packages/global/scss/components/blocks/_inbody-related-stories.scss
@@ -16,9 +16,6 @@
 
       &__contents {
         flex-direction: row-reverse;
-        @include media-breakpoint-up(lg) {
-          flex-direction: column;
-        }
       }
 
       $image-size: 112px;
@@ -89,17 +86,13 @@
   &__header {
     @include skin-typography($style: "section-header");
     font-size: 22px !important;
-    margin-bottom: 1rem !important;
+    margin-bottom: 0.5rem !important;
     line-height: 1rem !important;
   }
-  .card-deck-flow--4-cols {
-    .card-deck-flow__node {
-      @include media-breakpoint-up(sm) {
-        @include make-col(6);
-      }
-      @include media-breakpoint-up(lg) {
-        @include make-col(3);
-      }
+  .card-deck-flow__node {
+    padding: 0px;
+    .node {
+      padding: 10px;
     }
   }
 }


### PR DESCRIPTION
![Screenshot from 2023-07-25 11-05-31](https://github.com/parameter1/randall-reilly-websites/assets/46794001/53672965-4526-40b3-990c-d59f4c26d545)
![Screenshot from 2023-07-25 11-05-41](https://github.com/parameter1/randall-reilly-websites/assets/46794001/2bef644e-7653-414d-9aae-d6f23138e68c)
![Screenshot from 2023-07-25 11-05-52](https://github.com/parameter1/randall-reilly-websites/assets/46794001/1ad82a22-bdb4-4579-99ad-892baf48d1ce)
![Screenshot from 2023-07-25 11-09-30](https://github.com/parameter1/randall-reilly-websites/assets/46794001/ab51498a-8fae-4ed2-8bf4-262349bad9cc)


Will need to reproduced likewise within https://github.com/parameter1/randall-reilly-websites/pull/565 