### PR TITLE
Truck History Report adjustments to layout styles & social follow title 

### DIFF
--- a/packages/rigdig/scss/rigdig.scss
+++ b/packages/rigdig/scss/rigdig.scss
@@ -24,6 +24,7 @@
   top: 20px;
 }
 .rigdig {
+  $self: &;
   &_logo {
     padding-right: map-get($spacers, 2)
   }
@@ -56,7 +57,10 @@
     .pull-graphic {
       right: -26px;
       margin-bottom: -16px;
-      @include border-radius($theme-page-border-radius, 16px);
+      @include border-radius($theme-page-border-radius, 10px);
+      #{ $self }__graphic {
+        @include border-radius($theme-page-border-radius, 10px);
+      }
     }
   }
   &__border-wrapper {
@@ -78,7 +82,7 @@
   &__section-sub-title {
     font-weight: 700;
     font-size: 18px;
-
+    width: 100%;
   }
   &__cta {
     border-radius: 40px;
@@ -97,7 +101,7 @@
   //   width: calc(100% - 400px);
   // }
   &__card-graphic {
-    @include border-radius($theme-page-border-radius, 16px);
+    @include border-radius($theme-page-border-radius, 10px);
     max-width: 100%;
   }
   &__graphic {

--- a/sites/truckhistoryreport.com/server/styles/index.scss
+++ b/sites/truckhistoryreport.com/server/styles/index.scss
@@ -33,7 +33,7 @@ $skin-newsletter-signup-inline-btn-color: #460c0e;
   }
 }
 /*! critical:start */
-.site-menu,
+.site-menu--open,
 .site-footer {
   .social-follow .social-follow__header {
     visibility: hidden;

--- a/sites/truckhistoryreport.com/server/styles/index.scss
+++ b/sites/truckhistoryreport.com/server/styles/index.scss
@@ -32,3 +32,29 @@ $skin-newsletter-signup-inline-btn-color: #460c0e;
     margin-bottom: 0;
   }
 }
+/*! critical:start */
+.site-menu,
+.site-footer {
+  .social-follow .social-follow__header {
+    visibility: hidden;
+    position: relative;
+    &:after {
+      visibility: visible;
+      content: " Follow Overdrive";
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+  }
+}
+
+.rigdig {
+  $self: &;
+  &__section-sub-title {
+    + #{ $self } + p.small {
+      margin-top: map-get($spacers, 2);
+    }
+  }
+}
+
+/*! critical:end */

--- a/sites/truckhistoryreport.com/server/templates/index.marko
+++ b/sites/truckhistoryreport.com/server/templates/index.marko
@@ -32,7 +32,7 @@ $ console.log(site, config)
             Welcome to the new RigDig Truck History Report!
           </h3>
           <p>
-            RigDig Truck History Report has a new look and a new home. Looking for <a href="/" title="">RigDigBI</a>?
+            RigDig Truck History Report has a new look and a new home. Looking for <a href="https://rigdigbi.com/" title="RigDig BI">RigDigBI</a>?
           </p>
         </div>
       </div>

--- a/sites/truckhistoryreport.com/server/templates/index.marko
+++ b/sites/truckhistoryreport.com/server/templates/index.marko
@@ -1,7 +1,9 @@
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
 
 $ const { id, alias, name, pageNode } = input;
-$ const { GAM } = out.global;
+$ const { site, config } = out.global;
+
+$ console.log(site, config)
 
 <global-website-section-default-layout
   id=id
@@ -30,7 +32,7 @@ $ const { GAM } = out.global;
             Welcome to the new RigDig Truck History Report!
           </h3>
           <p>
-            RigDig Truck History Report has a new look and a new home. Looking for RigDigBI? Looking to access past reports?
+            RigDig Truck History Report has a new look and a new home. Looking for <a href="/" title="">RigDigBI</a>?
           </p>
         </div>
       </div>
@@ -114,7 +116,7 @@ $ const { GAM } = out.global;
               attrs={}
             />
           </marko-web-block>
-          <p>
+          <p class="small">
             A quick summary of junk, salvage, total loss, title & odometer flags. Indicators of accidents, inspections, carriers, and UCC lien records.
           </p>
         </div>
@@ -131,7 +133,7 @@ $ const { GAM } = out.global;
               attrs={}
             />
           </marko-web-block>
-          <p>
+          <p class="small">
             Inspection an accident history by past USDOT operators of the vehicle with details on violations issued or severity of the crash.
           </p>
         </div>
@@ -148,7 +150,7 @@ $ const { GAM } = out.global;
               attrs={}
             />
           </marko-web-block>
-          <p>
+          <p class="small">
             Branded titles indicate a vehicle has suffered damage serious enough to affect the reliability, safety, and value of the vehicle permanently.
           </p>
         </div>
@@ -165,7 +167,7 @@ $ const { GAM } = out.global;
               attrs={}
             />
           </marko-web-block>
-          <p>
+          <p class="small">
             Title history of a vehicle by date the title changed and state where the title record was updated.
           </p>
         </div>


### PR DESCRIPTION
Update social label to be `Follow Overdrive`
<img width="420" alt="Screen Shot 2023-09-07 at 12 37 43 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/d0e14dcb-8292-4ace-b806-868b1fbbb6cf">

Add small class to adjust font size on paragraphs under images
<img width="724" alt="Screen Shot 2023-09-07 at 12 38 01 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/59dd061c-81e7-4769-abc8-cac14122c1ee">

Fix h6 tags to prevent element wrapping:
<img width="1175" alt="Screen Shot 2023-09-07 at 12 38 30 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/78ef8d2d-12e2-4344-b585-1a255ead5d0d">
