### PR TITLE
Update invalid & report not found error handling with widget

### DIFF
--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -52,7 +52,18 @@
         </button>
       </div>
       <alert-error v-if="error" title="Unable to look up VIN.">
-        <p>We couldn't find the Vehicle Identification Number you supplied.</p>
+        <!-- Invalid Vin Provided and API returns 400 -->
+        <p v-if="status === 400">
+          An invalid Vehicle Identification Number you supplied.
+        </p>
+        <!-- Found the vin, and api returns okay but no reports & we return a 400 internally-->
+        <p v-else-if="status === 404">
+          No report could be found with the Vehicle Identification Number you supplied.
+        </p>
+        <!-- Display other abnormal errors -->
+        <p v-else>
+          {{ error }}
+        </p>
       </alert-error>
       <div v-if="withDetails" class="rigdig-widget__form-group--details">
         <label class="rigdig-widget__label">
@@ -162,6 +173,7 @@ export default {
   data: () => ({
     attempted: false,
     error: null,
+    status: null,
     loading: false,
     vin: null,
     verified: false,
@@ -182,6 +194,7 @@ export default {
     },
     async handleSubmit() {
       this.error = null;
+      this.status = null;
       this.loading = true;
       try {
         const response = await fetch('/__rigdig/verify', {
@@ -200,6 +213,7 @@ export default {
           }
           const error = new Error(message);
           error.code = response.status;
+          this.status = error.code;
           throw error;
         }
         const { PoweredByVinLink: { year, make, model } } = await response.json();


### PR DESCRIPTION
Update the error message to more user friendly version when you get errors from verify route:

<table>
<tr>
<th>
Invalid pin & 400 error directly from api
</th>
<th>
Report not found, but valid vin & we fire 404 error on /verify
</td>
</tr>
<tr>
<td>
<img width="415" alt="Screen Shot 2023-09-18 at 11 47 01 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/1cc49d06-132e-4330-811a-e979ca36dbd1">
</td>
<td>
<img width="411" alt="Screen Shot 2023-09-18 at 11 47 14 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/b8296590-0ec0-4d74-ae26-7d3bba45e1d3">
</td>
</tr>
</table>