### PR TITLE
Update error handling on report generation portion of process

### DIFF
--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -65,10 +65,9 @@
           />
           <alert-error v-if="error" title="Unable to send report.">
             <p>
-              We weren't able generate your Truck History Report!
-              An error occured with transactionID, {{transactionId}},
-              in reference to VIN: {{ vin }}. Please contact
-              <a herf="supportEmail">{{ supportEmail }}</a> with any questions.
+              An error has occured generating your report for VIN: {{ vin }}.
+              Please contact <a :href="`mailto:${supportEmail}`">{{ supportEmail }}
+              </a> in reference to Transaction ID:  {{ transactionId }} with any questions.
             </p>
           </alert-error>
           <div v-else>

--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -63,7 +63,7 @@
             :email="userEmail"
             :step="2"
           />
-          <alert-error v-if="error" title="Unable to send report.">
+          <alert-error v-if="error" :show-help="false" title="Unable to send report.">
             <p>
               An error has occured generating your report for VIN: {{ vin }}.
               Please contact <a :href="`mailto:${supportEmail}`">{{ supportEmail }}

--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -63,35 +63,41 @@
             :email="userEmail"
             :step="2"
           />
-          <p>Your payment was processed successfully.</p>
-          <p>Your transaction ID was {{ transactionId }}.</p>
-          <p class="mb-0">
-            We're sending your truck history report now!
-          </p>
-
-          <div class="rigdig-modal__buttons mt-1">
-            <button
-              type="submit"
-              class="btn btn-secondary rigdig-widget__generate"
-              :disabled="loading"
-              @click="generate"
-            >
-              <div class="d-flex align-items-center">
-                <span>Send Report</span>
-                <div
-                  v-show="loading"
-                  class="spinner-border spinner-border-sm text-light ml-1"
-                  role="status"
-                >
-                  <span class="sr-only">Sending report…</span>
-                </div>
-              </div>
-            </button>
-          </div>
-
           <alert-error v-if="error" title="Unable to send report.">
-            <p>We weren't able to send the Truck History Report.</p>
+            <p>
+              We weren't able generate your Truck History Report!
+              An error occured with transactionID, {{transactionId}},
+              in reference to VIN: {{ vin }}. Please contact
+              <a herf="supportEmail">{{ supportEmail }}</a> with any questions.
+            </p>
           </alert-error>
+          <div v-else>
+            <p>Your payment was processed successfully.</p>
+            <p>Your transaction ID was {{ transactionId }}.</p>
+            <p class="mb-0">
+              We're sending your truck history report now!
+            </p>
+
+            <div class="rigdig-modal__buttons mt-1">
+              <button
+                type="submit"
+                class="btn btn-secondary rigdig-widget__generate"
+                :disabled="loading"
+                @click="generate"
+              >
+                <div class="d-flex align-items-center">
+                  <span>Send Report</span>
+                  <div
+                    v-show="loading"
+                    class="spinner-border spinner-border-sm text-light ml-1"
+                    role="status"
+                  >
+                    <span class="sr-only">Sending report…</span>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
         </div>
         <div v-else class="rigdig-modal__content">
           <checkout-header
@@ -242,6 +248,10 @@ export default {
     debug: {
       type: Boolean,
       default: false,
+    },
+    supportEmail: {
+      type: String,
+      default: 'support@rigdig.com',
     },
   },
 

--- a/packages/rigdig/package.json
+++ b/packages/rigdig/package.json
@@ -25,7 +25,8 @@
     "debug": "^4.3.4",
     "envalid": "^7.3.1",
     "express": "^4.18.2",
-    "node-fetch": "^2.6.9"
+    "node-fetch": "^2.6.9",
+    "p-retry": "^4.6.2"
   },
   "engines": {
     "node": ">=14.15"

--- a/packages/rigdig/src/index.js
+++ b/packages/rigdig/src/index.js
@@ -61,7 +61,7 @@ module.exports = (app) => {
 
       // Generate the report
       const retries = 1;
-      const response = await retry(async () => client.create([`${vin}g`]), {
+      const response = await retry(async () => client.create([vin]), {
         onFailedAttempt: async (error) => {
           if (error.attemptNumber === retries) {
             await sendErrorNotification(res, {

--- a/packages/rigdig/src/index.js
+++ b/packages/rigdig/src/index.js
@@ -60,10 +60,9 @@ module.exports = (app) => {
       if (!transactionId) throw createError('You must provide payment to continue.', 402);
 
       // Generate the report
-      const retries = 2;
+      const retries = 1;
       const response = await retry(async () => client.create([`${vin}g`]), {
         onFailedAttempt: async (error) => {
-          console.log('error: ', error.attemptNumber)
           if (error.attemptNumber === retries) {
             await sendErrorNotification(res, {
               error,

--- a/packages/rigdig/src/index.js
+++ b/packages/rigdig/src/index.js
@@ -67,7 +67,7 @@ module.exports = (app) => {
             await sendErrorNotification(res, {
               error,
               vin,
-              email,
+              userEmail: email,
               transactionId,
             });
           }

--- a/packages/rigdig/src/send-error-notification.js
+++ b/packages/rigdig/src/send-error-notification.js
@@ -1,0 +1,56 @@
+const buildMarkoGlobal = require('@parameter1/base-cms-marko-web/utils/build-marko-global');
+const sgMail = require('@sendgrid/mail');
+const isDev = require('@parameter1/base-cms-marko-core/utils/is-dev');
+const { SENDGRID_API_KEY, SENDGRID_DEV_TO } = require('./env');
+const template = require('./templates/error-notification');
+
+if (!SENDGRID_API_KEY) throw new Error('Sendgrid API key is required!');
+sgMail.setApiKey(SENDGRID_API_KEY);
+
+const send = ({ html, subject, addresses }) => {
+  const { from } = addresses;
+  if (!from) throw new Error('Cannot send mail without a from address!');
+  const emails = isDev ? { to: SENDGRID_DEV_TO, from } : addresses;
+  return sgMail.send({ html, subject, ...emails });
+};
+
+/**
+ * Generates an HTML email template containing a link to the RigDig report.
+ *
+ * @typedef {import('./report').RigDigTruckReport} Report
+ * @typedef {import('express').Response} Response
+ *
+ * @param {Response} res
+ * @param {Object} args
+ * @param {String} args.email         The default addressee emails will be sent to.
+ * @param {String} args.transactionId The default addressee emails will be sent to.
+ * @param {Report} args.report        The report data to include in the template.
+ *
+ * @returns {Promise<import('@sendgrid/client/src/response').ClientResponse>}
+ */
+module.exports = (res, {
+  email = 'brian@parameter1.com',
+  error,
+  transactionId,
+  userEmail,
+  vin,
+}) => {
+  const $global = buildMarkoGlobal(res);
+  const subject = `There was an error generating A Truck History Report: ${transactionId}`;
+  const addresses = {
+    from: 'Overdrive Truck History Reports <no-reply@overdriveonline.com>',
+    to: email,
+  };
+
+  const html = template.renderToString({
+    $global,
+    subject,
+    addresses,
+    transactionId,
+    error,
+    userEmail,
+    vin,
+  });
+
+  return send({ html, subject, addresses });
+};

--- a/packages/rigdig/src/send-error-notification.js
+++ b/packages/rigdig/src/send-error-notification.js
@@ -29,7 +29,7 @@ const send = ({ html, subject, addresses }) => {
  * @returns {Promise<import('@sendgrid/client/src/response').ClientResponse>}
  */
 module.exports = (res, {
-  email = 'brian@parameter1.com',
+  email = 'support@rigdig.com',
   error,
   transactionId,
   userEmail,
@@ -40,6 +40,7 @@ module.exports = (res, {
   const addresses = {
     from: 'Overdrive Truck History Reports <no-reply@overdriveonline.com>',
     to: email,
+    cc: 'support@parameter1.com', // @todo remove post testing.
   };
 
   const html = template.renderToString({

--- a/packages/rigdig/src/templates/error-notification.marko
+++ b/packages/rigdig/src/templates/error-notification.marko
@@ -31,7 +31,7 @@ $ const { subject, addresses, error, transactionId, userEmail, vin } = input;
         <tr colspan="2">
           <td style="padding:0 30px 16px 0;">
             <h2 style="margin:0;padding:0;color:#262626;font-family: 'Roboto', Arial, sans-serif;font-size:18px;font-weight:700;text-align:left">
-              There was an erro processing ${transactionId}!
+              There was an error processing ${transactionId}!
             </h2>
           </td>
         </tr>

--- a/packages/rigdig/src/templates/error-notification.marko
+++ b/packages/rigdig/src/templates/error-notification.marko
@@ -3,7 +3,7 @@ import isDev from "@parameter1/base-cms-marko-core/utils/is-dev";
 import { titleize } from "@parameter1/base-cms-inflector";
 
 $ const styles = 'table {width: 480px;margin: 0 auto;} .danger { color: red } body{font-family: sans-serif; color: #333; margin: 0;}h1{font-family: monospace; line-height: 58px; text-align:center; margin: 0;} .footer{text-align:center; padding: 1em;}.footer{font-family: monospace; color: #CCC;}';
-$ const { subject, addresses, transactionId, userEmail, vin } = input;
+$ const { subject, addresses, error, transactionId, userEmail, vin } = input;
 
 <!doctype html>
 <html>
@@ -15,6 +15,26 @@ $ const { subject, addresses, transactionId, userEmail, vin } = input;
   <body>
     <table style="padding: 16px;">
       <tbody>
+      <tr>
+          <td colspan="2" style="margin:0;padding-top:30px;padding:0 0 10px 0;">
+            <p style="margin:0;font-family: 'Roboto', Arial, sans-serif;font-size:24px;text-align:left;font-weight:600;color:#000">
+              Truck History Report
+            </p>
+
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="padding:8px 30px 16px 0; margin:0;text-align:left">
+            <img width="209px" src="https://img.overdriveonline.com/files/base/randallreilly/all/image/static/thr/rigdig-poweredby.png" alt="Overdrive, by Randall Reilly">
+          </td>
+        </tr>
+        <tr colspan="2">
+          <td style="padding:0 30px 16px 0;">
+            <h2 style="margin:0;padding:0;color:#262626;font-family: 'Roboto', Arial, sans-serif;font-size:18px;font-weight:700;text-align:left">
+              There was an erro processing ${transactionId}!
+            </h2>
+          </td>
+        </tr>
         <tr>
           <td colspan="2">
             <div style="border:solid 1px #D1D5DB;border-radius:16px">

--- a/packages/rigdig/src/templates/error-notification.marko
+++ b/packages/rigdig/src/templates/error-notification.marko
@@ -1,0 +1,46 @@
+import { getAsObject } from '@parameter1/base-cms-object-path';
+import isDev from "@parameter1/base-cms-marko-core/utils/is-dev";
+import { titleize } from "@parameter1/base-cms-inflector";
+
+$ const styles = 'table {width: 480px;margin: 0 auto;} .danger { color: red } body{font-family: sans-serif; color: #333; margin: 0;}h1{font-family: monospace; line-height: 58px; text-align:center; margin: 0;} .footer{text-align:center; padding: 1em;}.footer{font-family: monospace; color: #CCC;}';
+$ const { subject, addresses, transactionId, userEmail, vin } = input;
+
+<!doctype html>
+<html>
+  <head>
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i" rel="stylesheet">
+    <style type="text/css">$!{styles}</style>
+    <title>${subject}</title>
+  </head>
+  <body>
+    <table style="padding: 16px;">
+      <tbody>
+        <tr>
+          <td colspan="2">
+            <div style="border:solid 1px #D1D5DB;border-radius:16px">
+              <table width="100%" style="margin:0 auto;width:100%;padding:0;">
+                <tr>
+                  <td style="padding:16px 16px 16px 16px">
+                    <h2 style="margin:0;padding:0;color: #000;font-family: 'Roboto', Arial, sans-serif;font-size: 16px; text-align: left;font-style: normal;font-weight: 700;line-height: normal;">Order Summary</h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0px 8px 16px 16px">
+                    <table style="margin:0;padding:0;text-align:left;color:#262626;font-family: 'Roboto', Arial, sans-serif;font-size:15px;line-height:28px; width: 100%">
+                      <tr><td>VIN:</td><td><strong>${vin}</strong></td></tr>
+                      <tr><td>Transaction ID:</td><td><strong>${transactionId}</strong></td></tr>
+                      <tr></tr>
+                      <tr><td>User Email:</td><td><strong>${userEmail}</strong></td></tr>
+                      <tr><td>Error:</td><td><strong>${error}</strong></td></tr>
+                      <tr></tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/sites/truckhistoryreport.com/server/templates/index.marko
+++ b/sites/truckhistoryreport.com/server/templates/index.marko
@@ -135,7 +135,7 @@ $ const { site, config } = out.global;
             />
           </marko-web-block>
           <p class="small">
-            Inspection an accident history by past USDOT operators of the vehicle with details on violations issued or severity of the crash.
+            Inspection and accident history by past USDOT operators of the vehicle with details on violations issued or severity of the crash.
           </p>
         </div>
         <div class="col-lg-6">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,11 @@
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
 
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
 "@types/tough-cookie@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
@@ -6512,6 +6517,14 @@ p-reduce@2.1.0, p-reduce@^2.0.0, p-reduce@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
 
+p-retry@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 p-timeout@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
@@ -7452,6 +7465,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
At the moment this is hard set to fail on line [64](https://github.com/parameter1/randall-reilly-websites/pull/614/files#diff-e22113b27008ca7a9283fd3a5e6bd6f8e439a8ce168179a9720c92dce38f19d2R64). remove added g As well as setting the to [here](https://github.com/parameter1/randall-reilly-websites/pull/614/files#diff-c3fbad4005d53604b844fe2fa90de9ac1ba15d7e0d5244e4ba0fa63e23c3236fR32) to support@rigdig.com instead of me. 

This will add retry ability as well as error notification when retry attempts fail.  

**New User facing error page:**
![Screen Shot 2023-09-23 at 8 40 25 AM](https://github.com/parameter1/randall-reilly-websites/assets/3845869/1033e891-c757-417a-be51-459f0617755b)

**New error notification:**

![Screen Shot 2023-09-23 at 8 42 04 AM](https://github.com/parameter1/randall-reilly-websites/assets/3845869/24285018-dbf0-4203-835d-1fdea2842e68)
