### PR TITLE
Fix z-index when rigdig modal is present

### DIFF
--- a/sites/truckhistoryreport.com/server/styles/index.scss
+++ b/sites/truckhistoryreport.com/server/styles/index.scss
@@ -62,7 +62,7 @@ $skin-newsletter-signup-inline-btn-color: #460c0e;
 }
 /*! purgecss start ignore */
 .document-container:has(.rigdig-modal) {
-  z-index: 1501;
+  z-index: 15001;
 }
 /*! purgecss end ignore */
 .rigdig {


### PR DESCRIPTION
This ensures it will sit ontop of the header and footer

<img width="1380" alt="Screen Shot 2023-09-26 at 10 23 11 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/6c48fe2e-2f95-4ffe-8c6c-c34f0a3f1c79">
<img width="1371" alt="Screen Shot 2023-09-26 at 10 23 18 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/2984507f-2bed-4314-88b1-15d23b684e78">
