### PR TITLE
Remove top copy on step 2 of process

### DIFF
--- a/packages/rigdig/browser/checkout-header.vue
+++ b/packages/rigdig/browser/checkout-header.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <p class="rigdig-modal__copy">
+    <p v-if="step === 1" class="rigdig-modal__copy">
       We found a match for the VIN. To purchase the report, complete the payment process below.
     </p>
-    <p class="rigdig-modal__copy">
+    <p v-if="step === 1" class="rigdig-modal__copy">
       Reports are delivered instantly via email after payment.
     </p>
     <div class="rigdig-modal__promo">


### PR DESCRIPTION
Trying to tighten up the form on step 2 remove top 2 paragraphs 
 - We found a match for the VIN. To purchase the report, complete the payment process below.
 - Reports are delivered instantly via email after payment.



<img width="1400" alt="Screen Shot 2023-09-26 at 10 51 25 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/0091cdd0-633f-4d67-9879-2ad52a2a8da4">
<img width="1397" alt="Screen Shot 2023-09-26 at 10 51 37 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/2b0b1287-b182-493c-acc1-796b548f2054">
