### PR TITLE
Comment out user menu targets on Truck History Reports

### DIFF
--- a/sites/truckhistoryreport.com/config/navigation.js
+++ b/sites/truckhistoryreport.com/config/navigation.js
@@ -30,7 +30,7 @@ const utilities = [
 ];
 
 const mobileMenu = {
-  user: [],
+  // user: [],
   primary: [
     ...topics.primary,
     ...topics.expanded,
@@ -43,7 +43,7 @@ const mobileMenu = {
 
 const desktopMenu = {
   about: [...utilities],
-  user: [],
+  // user: [],
   sections: [
     ...topics.primary,
     ...topics.expanded,


### PR DESCRIPTION
This will prevent idx from injecting them into the menu.

routes will still work as expected.

<img width="1040" alt="Screen Shot 2023-09-29 at 12 53 38 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/f6f16ad1-f6be-427d-84a0-2eb093d70204">
<img width="454" alt="Screen Shot 2023-09-29 at 12 53 53 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/bd162de6-64f3-4fbf-99a6-a1dc2a5a084b">
