### PR TITLE
Add survey card promo block to CT hompage

### DIFF
--- a/packages/global/components/blocks/promos/ct-bev-survey-2.marko
+++ b/packages/global/components/blocks/promos/ct-bev-survey-2.marko
@@ -1,24 +1,24 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const blockName = "pib-page-card";
-$ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static/";
-$ const manualSrc = "rigdigreport.jpg?auto=format&w=120&fit=crop";
+$ const logoRoot = "https://img.cleantrucking.com/files/base/randallreilly/all/image/2023/10/";
+$ const manualSrc = "Screen_Shot_2023_10_11_at_9.33.34_AM.6526b25db7927.png?auto=format&w=120&fit=crop";
 
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="inner-wrapper">
     <div>
       <marko-web-element block-name=blockName name="title">
-        @TODO UPDATE: Hydrogen Fuel Cell & BEV Survey
+        Hydrogen Fuel Cell & BEV Survey<span class="small">(duplicate)</span>
       </marko-web-element>
       <marko-web-element block-name=blockName name="description">
-        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ.
+        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ. After approximately two weeks, a total of 176 owner-operators under their own authority, 113 owner-operators leased or assigned to a carrier and 82 fleet executives and 36 fleet employees from fleets with 10 or more power units had completed and submitted the questionnaire for a total of 407 qualified responses. Cross-tabulations based on respondent type are provided for each question when applicable.
       </marko-web-element>
       <marko-web-link
         class=`btn btn-primary ${blockName}__download-btn`
-        href="https://randallreilly.infogram.com/1pxdlkgwex9xp9aqxper6z7e9xsn271j7d0"
+        href="/15636227"
         title="View Survey"
       >
-        View Survey
+        View Infogram
       </marko-web-link>
     </div>
     <marko-web-img

--- a/packages/global/components/blocks/promos/ct-bev-survey-2.marko
+++ b/packages/global/components/blocks/promos/ct-bev-survey-2.marko
@@ -1,0 +1,31 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const blockName = "pib-page-card";
+$ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static/";
+$ const manualSrc = "rigdigreport.jpg?auto=format&w=120&fit=crop";
+
+<marko-web-block name=blockName>
+  <marko-web-element block-name=blockName name="inner-wrapper">
+    <div>
+      <marko-web-element block-name=blockName name="title">
+        @TODO UPDATE: Hydrogen Fuel Cell & BEV Survey
+      </marko-web-element>
+      <marko-web-element block-name=blockName name="description">
+        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ.
+      </marko-web-element>
+      <marko-web-link
+        class=`btn btn-primary ${blockName}__download-btn`
+        href="https://randallreilly.infogram.com/1pxdlkgwex9xp9aqxper6z7e9xsn271j7d0"
+        title="View Survey"
+      >
+        View Survey
+      </marko-web-link>
+    </div>
+    <marko-web-img
+      class=`${blockName}__issue-cover`
+      src=`${logoRoot}/${manualSrc}`
+      srcset=[`${logoRoot}/${manualSrc}&dpr=2 2x`]
+      alt="View Survey"
+    />
+  </marko-web-element>
+</marko-web-block>

--- a/packages/global/components/blocks/promos/ct-bev-survey.marko
+++ b/packages/global/components/blocks/promos/ct-bev-survey.marko
@@ -1,0 +1,31 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const blockName = "pib-page-card";
+$ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static/";
+$ const manualSrc = "rigdigreport.jpg?auto=format&w=120&fit=crop";
+
+<marko-web-block name=blockName>
+  <marko-web-element block-name=blockName name="inner-wrapper">
+    <div>
+      <marko-web-element block-name=blockName name="title">
+        Hydrogen Fuel Cell & BEV Survey
+      </marko-web-element>
+      <marko-web-element block-name=blockName name="description">
+        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ.
+      </marko-web-element>
+      <marko-web-link
+        class=`btn btn-primary ${blockName}__download-btn`
+        href="https://randallreilly.infogram.com/1pxdlkgwex9xp9aqxper6z7e9xsn271j7d0"
+        title="View Survey"
+      >
+        View Survey
+      </marko-web-link>
+    </div>
+    <marko-web-img
+      class=`${blockName}__issue-cover`
+      src=`${logoRoot}/${manualSrc}`
+      srcset=[`${logoRoot}/${manualSrc}&dpr=2 2x`]
+      alt="View Survey"
+    />
+  </marko-web-element>
+</marko-web-block>

--- a/packages/global/components/blocks/promos/ct-bev-survey.marko
+++ b/packages/global/components/blocks/promos/ct-bev-survey.marko
@@ -1,8 +1,8 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const blockName = "pib-page-card";
-$ const logoRoot = "https://img.overdriveonline.com/files/base/randallreilly/all/image/static/";
-$ const manualSrc = "rigdigreport.jpg?auto=format&w=120&fit=crop";
+$ const logoRoot = "https://img.cleantrucking.com/files/base/randallreilly/all/image/2023/10/";
+$ const manualSrc = "Screen_Shot_2023_10_11_at_9.33.34_AM.6526b25db7927.png?auto=format&w=120&fit=crop";
 
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="inner-wrapper">
@@ -15,10 +15,10 @@ $ const manualSrc = "rigdigreport.jpg?auto=format&w=120&fit=crop";
       </marko-web-element>
       <marko-web-link
         class=`btn btn-primary ${blockName}__download-btn`
-        href="https://randallreilly.infogram.com/1pxdlkgwex9xp9aqxper6z7e9xsn271j7d0"
+        href="/15636227"
         title="View Survey"
       >
-        View Survey
+        View Infogram
       </marko-web-link>
     </div>
     <marko-web-img

--- a/packages/global/components/blocks/promos/marko.json
+++ b/packages/global/components/blocks/promos/marko.json
@@ -1,4 +1,10 @@
 {
+  "<global-ct-bev-survey-promo-block>": {
+    "template": "./ct-bev-survey.marko"
+  },
+  "<global-ct-bev-survey-2-promo-block>": {
+    "template": "./ct-bev-survey-2.marko"
+  },
   "<global-ovd-reader-rigs-submit-promo-block>": {
     "template": "./ovd-reader-rigs-submit.marko"
   },

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -547,7 +547,14 @@ label {
 }
 
 // overrides for inbody content injections
+/*! purgecss start ignore */
 .page-contents__content-body {
+  > .infogram-embed {
+    position: relative;
+    iframe {
+      max-width: 100%;
+    }
+  }
   .site-newsletter-menu {
     margin-right: -1rem;
     margin-left: -1rem;
@@ -555,5 +562,5 @@ label {
     padding-left: map-get($spacers, 2);
   }
 }
-
+/*! purgecss end ignore */
 /*! critical:end */

--- a/sites/cleantrucking.com/server/components/blocks/marko.json
+++ b/sites/cleantrucking.com/server/components/blocks/marko.json
@@ -1,0 +1,5 @@
+{
+  "<site-promo-card-rotation-block>": {
+    "template": "./promo-card-rotation.marko"
+  }
+}

--- a/sites/cleantrucking.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/cleantrucking.com/server/components/blocks/promo-card-rotation.marko
@@ -1,0 +1,5 @@
+import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
+import PromoA from "@randall-reilly/package-global/components/blocks/promos/ct-bev-survey-2";
+
+$ const PromotionComponent = shuffle([PromoA])[0];
+<${PromotionComponent} />

--- a/sites/cleantrucking.com/server/components/marko.json
+++ b/sites/cleantrucking.com/server/components/marko.json
@@ -1,4 +1,7 @@
 {
+  "taglib-imports": [
+    "./blocks/marko.json"
+  ],
   "<site-road-pro-facebook>": {
     "template": "./road-pro-facebook.marko"
   }

--- a/sites/cleantrucking.com/server/templates/content/company.marko
+++ b/sites/cleantrucking.com/server/templates/content/company.marko
@@ -75,4 +75,15 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
     <theme-client-side-most-popular-block />
   </@section>
+
+  <@section>
+    <theme-callout-cards-block>
+      <@slot>
+        <global-ct-bev-survey-promo-block />
+      </@slot>
+      <@slot>
+        <site-promo-card-rotation-block />
+      </@slot>
+    </theme-callout-cards-block>
+  </@section>
 </global-content-company-layout>

--- a/sites/cleantrucking.com/server/templates/content/index.marko
+++ b/sites/cleantrucking.com/server/templates/content/index.marko
@@ -21,4 +21,15 @@ $ const { id, type, pageNode, ...rest } = input;
       <theme-client-side-most-popular-block />
     </div>
   </@section>
+
+  <@section>
+    <theme-callout-cards-block>
+      <@slot>
+        <global-ct-bev-survey-promo-block />
+      </@slot>
+      <@slot>
+        <site-promo-card-rotation-block />
+      </@slot>
+    </theme-callout-cards-block>
+  </@section>
 </global-content-default-layout>

--- a/sites/cleantrucking.com/server/templates/content/product.marko
+++ b/sites/cleantrucking.com/server/templates/content/product.marko
@@ -68,4 +68,14 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
     <theme-client-side-most-popular-block />
   </@section>
+  <@section>
+    <theme-callout-cards-block>
+      <@slot>
+        <global-ct-bev-survey-promo-block />
+      </@slot>
+      <@slot>
+        <site-promo-card-rotation-block />
+      </@slot>
+    </theme-callout-cards-block>
+  </@section>
 </global-content-product-layout>

--- a/sites/cleantrucking.com/server/templates/index.marko
+++ b/sites/cleantrucking.com/server/templates/index.marko
@@ -37,4 +37,15 @@ $ const { id, alias, name, pageNode } = input;
     <theme-content-card-deck-block alias="fleet-profiles" query-params={ limit: 4 } />
   </@section>
 
+  <@section>
+    <theme-callout-cards-block>
+      <@slot>
+        <global-ct-bev-survey-promo-block />
+      </@slot>
+      <@slot>
+        <site-promo-card-rotation-block />
+      </@slot>
+    </theme-callout-cards-block>
+  </@section>
+
 </global-website-section-home-layout>

--- a/sites/cleantrucking.com/server/templates/website-section/index.marko
+++ b/sites/cleantrucking.com/server/templates/website-section/index.marko
@@ -20,4 +20,14 @@ $ const { id, alias, name, pageNode } = input;
   <@section>
     <theme-client-side-most-popular-block />
   </@section>
+  <@section>
+    <theme-callout-cards-block>
+      <@slot>
+        <global-ct-bev-survey-promo-block />
+      </@slot>
+      <@slot>
+        <site-promo-card-rotation-block />
+      </@slot>
+    </theme-callout-cards-block>
+  </@section>
 </global-website-section-feed-layout>


### PR DESCRIPTION
Add two promo cards to display survey reports for CT home page as well as bottom of all other pages.

### Cards at bottom of pages:
<img width="638" alt="Screen Shot 2023-10-11 at 9 45 11 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/e2ead04a-ab7d-4547-a542-1221325327e0">

### Different stages of gate filled out & full access:
<img width="1315" alt="Screen Shot 2023-10-11 at 9 46 44 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/c07637e4-cc95-49aa-b56c-6ef8d68f6371">
<img width="834" alt="Screen Shot 2023-10-11 at 9 47 35 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/de3fd4d4-ba52-4b1f-8feb-373ec8d26960">
<img width="840" alt="Screen Shot 2023-10-11 at 9 58 07 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/5f90506b-5d00-42bf-bf75-babb2f11e804">


