### PR TITLE
Prevent overflow from causing scroll on mobile

### DIFF
--- a/packages/rigdig/scss/rigdig.scss
+++ b/packages/rigdig/scss/rigdig.scss
@@ -52,6 +52,7 @@ $wrapper-border-radius: 10px !default;
     margin-right: auto;
     background-color: #f0f1f2;
     border-radius: $wrapper-border-radius;
+    overflow: hidden;
     margin-bottom: 30px;
     margin-top: 30px;
     position: relative;


### PR DESCRIPTION
These __bg-wrapper already have negative margins left/right to pull them out to the edge of the page.  This prevents anything from falling off the page, also preventing a left right scroll bar.

Production:
<img width="755" alt="Screen Shot 2023-10-12 at 3 26 59 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/9280daca-dd17-4106-8a7e-bb46b2e024eb">

Dev:
<img width="600" alt="Screen Shot 2023-10-12 at 3 27 08 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/12feb640-f747-4317-ba1f-d5d90dafabcd">
