### PR TITLE
Add simple css to widen survey page

### DIFF
--- a/sites/cleantrucking.com/server/styles/index.scss
+++ b/sites/cleantrucking.com/server/styles/index.scss
@@ -20,3 +20,12 @@ $skin-newsletter-signup-inline-btn-color: #145624;
     width: auto;
   }
 }
+
+.page {
+  &--content-15636227 {
+    .content-page-header,
+    .content-page-body {
+      max-width: initial;
+    }
+  }
+}


### PR DESCRIPTION
Remove 700px max width on Survey Report content landing page.  At the moment this is id specific.  If this increases we will look at making this label/config based.

<img width="840" alt="Screen Shot 2023-10-16 at 10 03 45 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/61a38992-b560-43a7-a5a3-ea2df1567465">
