### PR TITLE
Update ct survey promo calls

### DIFF
--- a/packages/global/components/blocks/promos/bev-survey-image-only.marko
+++ b/packages/global/components/blocks/promos/bev-survey-image-only.marko
@@ -1,18 +1,12 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const blockName = "pib-page-card";
+$ const blockName = "bev-survey-page-card";
 $ const logoRoot = "https://img.cleantrucking.com/files/base/randallreilly/all/image/2023/10/";
-$ const manualSrc = "Screen_Shot_2023_10_11_at_9.33.34_AM.6526b25db7927.png?auto=format&w=120&fit=crop";
+$ const manualSrc = "overdrive_and_ccj_2023_hydrogen_fuel_cell_and_bev_survey.652d6206523f6.png?auto=format&w=320&fit=crop";
 
-<marko-web-block name=blockName>
+<marko-web-block name=blockName modifiers=["image-only"]>
   <marko-web-element block-name=blockName name="inner-wrapper">
     <div>
-      <marko-web-element block-name=blockName name="title">
-        Hydrogen Fuel Cell & BEV Survey
-      </marko-web-element>
-      <marko-web-element block-name=blockName name="description">
-        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ.
-      </marko-web-element>
       <marko-web-link
         class=`btn btn-primary ${blockName}__download-btn`
         href="/15636227"

--- a/packages/global/components/blocks/promos/bev-survey-text-only.marko
+++ b/packages/global/components/blocks/promos/bev-survey-text-only.marko
@@ -1,0 +1,23 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const blockName = "bev-survey-page-card";
+
+<marko-web-block name=blockName modifiers=["text-only"]>
+  <marko-web-element block-name=blockName name="inner-wrapper">
+    <div>
+      <marko-web-element block-name=blockName name="title">
+        Hydrogen Fuel Cell & BEV Survey
+      </marko-web-element>
+      <marko-web-element block-name=blockName name="description">
+        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ. After approximately two weeks, a total of 176 owner-operators under their own authority, 113 owner-operators leased or assigned to a carrier and 82 fleet executives and 36 fleet employees from fleets with 10 or more power units had completed and submitted the questionnaire for a total of 407 qualified responses. Cross-tabulations based on respondent type are provided for each question when applicable.
+      </marko-web-element>
+      <marko-web-link
+        class=`btn btn-primary ${blockName}__download-btn`
+        href="/15636227"
+        title="View Survey"
+      >
+        View Infogram
+      </marko-web-link>
+    </div>
+  </marko-web-element>
+</marko-web-block>

--- a/packages/global/components/blocks/promos/bev-survey.marko
+++ b/packages/global/components/blocks/promos/bev-survey.marko
@@ -1,17 +1,17 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const blockName = "pib-page-card";
+$ const blockName = "bev-survey-page-card";
 $ const logoRoot = "https://img.cleantrucking.com/files/base/randallreilly/all/image/2023/10/";
-$ const manualSrc = "Screen_Shot_2023_10_11_at_9.33.34_AM.6526b25db7927.png?auto=format&w=120&fit=crop";
+$ const manualSrc = "overdrive_and_ccj_2023_hydrogen_fuel_cell_and_bev_survey.652d6206523f6.png?auto=format&w=120&fit=crop";
 
-<marko-web-block name=blockName>
+<marko-web-block name=blockName  modifiers=[]>
   <marko-web-element block-name=blockName name="inner-wrapper">
     <div>
       <marko-web-element block-name=blockName name="title">
-        Hydrogen Fuel Cell & BEV Survey<span class="small">(duplicate)</span>
+        Hydrogen Fuel Cell & BEV Survey
       </marko-web-element>
       <marko-web-element block-name=blockName name="description">
-        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ. After approximately two weeks, a total of 176 owner-operators under their own authority, 113 owner-operators leased or assigned to a carrier and 82 fleet executives and 36 fleet employees from fleets with 10 or more power units had completed and submitted the questionnaire for a total of 407 qualified responses. Cross-tabulations based on respondent type are provided for each question when applicable.
+        The following survey was sent as a link in an email cover message in February 2023 to the newsletter lists for Overdrive and CCJ.
       </marko-web-element>
       <marko-web-link
         class=`btn btn-primary ${blockName}__download-btn`

--- a/packages/global/components/blocks/promos/marko.json
+++ b/packages/global/components/blocks/promos/marko.json
@@ -1,9 +1,12 @@
 {
-  "<global-ct-bev-survey-promo-block>": {
-    "template": "./ct-bev-survey.marko"
+  "<global-bev-survey-promo-block>": {
+    "template": "./bev-survey.marko"
   },
-  "<global-ct-bev-survey-2-promo-block>": {
-    "template": "./ct-bev-survey-2.marko"
+  "<global-bev-survey-image-only-promo-block>": {
+    "template": "./bev-survey-image-only.marko"
+  },
+  "<global-bev-survey-text-only-promo-block>": {
+    "template": "./bev-survey-text-only.marko"
   },
   "<global-ovd-reader-rigs-submit-promo-block>": {
     "template": "./ovd-reader-rigs-submit.marko"

--- a/packages/global/scss/components/blocks/_promo-cards.scss
+++ b/packages/global/scss/components/blocks/_promo-cards.scss
@@ -1,0 +1,39 @@
+.bev-survey-page-card {
+  $self: &;
+  height: 100%;
+  padding: 24px;
+  background-color: $gray-100;
+  border-radius: 4px;
+
+  &__title {
+    margin-bottom: 8px;
+    @include skin-typography($style: "header-2");
+  }
+
+  &__description {
+    margin-bottom: 16px;
+    @include skin-typography($style: "small-body-text");
+  }
+
+  &__inner-wrapper {
+    display: flex;
+  }
+
+  &__issue-cover {
+    align-self: flex-start;
+    width: 120px;
+    margin-left: 24px;
+  }
+
+  &--image-only {
+    #{ $self }__inner-wrapper {
+      flex-direction: column-reverse;
+    }
+    #{ $self }__issue-cover {
+      width: 100%;
+      margin-left: 0;
+      margin-bottom: map-get($spacers, block);
+      align-self: center;
+    }
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -209,6 +209,7 @@
 // skin components
 @import "./components/blocks/ccj-solutions-summit";
 @import "./components/blocks/ccj-top-250";
+@import "./components/blocks/promo-cards";
 /*! critical:start|content */
 @import "./components/content-meter";
 /*! critical:end */

--- a/sites/cleantrucking.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/cleantrucking.com/server/components/blocks/promo-card-rotation.marko
@@ -1,5 +1,5 @@
 import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
-import PromoA from "@randall-reilly/package-global/components/blocks/promos/ct-bev-survey-2";
+import PromoA from "@randall-reilly/package-global/components/blocks/promos/bev-survey-text-only";
 
 $ const PromotionComponent = shuffle([PromoA])[0];
 <${PromotionComponent} />

--- a/sites/cleantrucking.com/server/templates/content/company.marko
+++ b/sites/cleantrucking.com/server/templates/content/company.marko
@@ -79,7 +79,7 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
     <theme-callout-cards-block>
       <@slot>
-        <global-ct-bev-survey-promo-block />
+        <global-bev-survey-image-only-promo-block />
       </@slot>
       <@slot>
         <site-promo-card-rotation-block />

--- a/sites/cleantrucking.com/server/templates/content/index.marko
+++ b/sites/cleantrucking.com/server/templates/content/index.marko
@@ -25,7 +25,7 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
     <theme-callout-cards-block>
       <@slot>
-        <global-ct-bev-survey-promo-block />
+        <global-bev-survey-image-only-promo-block />
       </@slot>
       <@slot>
         <site-promo-card-rotation-block />

--- a/sites/cleantrucking.com/server/templates/content/product.marko
+++ b/sites/cleantrucking.com/server/templates/content/product.marko
@@ -71,7 +71,7 @@ $ const { id, type, pageNode, ...rest } = input;
   <@section>
     <theme-callout-cards-block>
       <@slot>
-        <global-ct-bev-survey-promo-block />
+        <global-bev-survey-image-only-promo-block />
       </@slot>
       <@slot>
         <site-promo-card-rotation-block />

--- a/sites/cleantrucking.com/server/templates/index.marko
+++ b/sites/cleantrucking.com/server/templates/index.marko
@@ -40,7 +40,7 @@ $ const { id, alias, name, pageNode } = input;
   <@section>
     <theme-callout-cards-block>
       <@slot>
-        <global-ct-bev-survey-promo-block />
+        <global-bev-survey-image-only-promo-block />
       </@slot>
       <@slot>
         <site-promo-card-rotation-block />

--- a/sites/cleantrucking.com/server/templates/website-section/index.marko
+++ b/sites/cleantrucking.com/server/templates/website-section/index.marko
@@ -23,7 +23,7 @@ $ const { id, alias, name, pageNode } = input;
   <@section>
     <theme-callout-cards-block>
       <@slot>
-        <global-ct-bev-survey-promo-block />
+        <global-bev-survey-image-only-promo-block />
       </@slot>
       <@slot>
         <site-promo-card-rotation-block />


### PR DESCRIPTION
Update block names and calls to display image only and then text only version of the bev survey promo cards.  These wil display at the bottom of section and content pages.

<img width="1174" alt="Screen Shot 2023-10-16 at 11 21 37 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/66d31a7a-2e96-4e00-aec0-5727deae7487">
