### PR TITLE
Allow for addition of sales tax by zip code, Truck History Report form(s)

### DIFF
--- a/packages/payfabric/src/client.js
+++ b/packages/payfabric/src/client.js
@@ -99,12 +99,12 @@ module.exports = class ApiClient {
    * @param {IdentityXUserContext} args.user
    * @param {String} args.vin @todo memo/note?
    */
-  async createTransaction({ user, vin }) {
+  async createTransaction({ user, vin, salesTax }) {
     return this.request({
       endpoint: '/payment/api/transaction/create',
       body: JSON.stringify({
         // @todo additional details, customer reference?
-        Amount: 34.99,
+        Amount: 34.99 + salesTax,
         Currency: 'USD',
         Customer: user.id || user.email,
         SetupId: this.gatewayName,

--- a/packages/payfabric/src/utils/calculate-sales-tax.js
+++ b/packages/payfabric/src/utils/calculate-sales-tax.js
@@ -1,0 +1,20 @@
+const fetch = require('node-fetch');
+
+const hashedCredentials = 'MTEwMDA2NDgxNzoxQjQwNzg5OEE2Q0Q5NzI2';
+
+module.exports = async ({ postalCode }) => {
+  const request = await fetch(
+    `https://sandbox-rest.avatax.com/api/v2/taxrates/bypostalcode?country=US&postalCode=${postalCode}`,
+    {
+      method: 'GET',
+      headers: {
+        'content-type': 'application-json',
+        Authorization: `Basic ${hashedCredentials}`,
+      },
+    },
+  );
+  if (!request.ok) throw new Error('Bad fetch response, AvaTax');
+  const { totalRate } = await request.json();
+  // totalRate is a percent as decimal thus this should give us the dollar amount to add
+  return Number(Math.ceil((totalRate * 34.99) * 100) / 100);
+};

--- a/packages/rigdig/browser/checkout-header.vue
+++ b/packages/rigdig/browser/checkout-header.vue
@@ -28,6 +28,22 @@
         $34.99
       </strong>
     </div>
+    <div v-if="salesTax" class="rigdig-modal__promo-footer">
+      <span>
+        Sales Tax
+      </span>
+      <strong>
+        ${{ salesTax }}
+      </strong>
+    </div>
+    <div v-if="salesTax" class="rigdig-modal__promo-footer">
+      <span>
+        <b>Total</b>
+      </span>
+      <strong>
+        ${{ total }}
+      </strong>
+    </div>
     <div v-if="email" class="rigdig-modal__teaser border">
       <span>
         Deliver to <strong>{{ email }}</strong>
@@ -52,6 +68,10 @@ export default {
       type: Number,
       default: 1,
     },
+    salesTax: {
+      type: Number,
+      default: null,
+    },
     truckInfo: {
       type: String,
       required: true,
@@ -71,5 +91,11 @@ export default {
   },
 
   emits: ['back'],
+
+  computed: {
+    total() {
+      return this.salesTax + 34.99;
+    },
+  },
 };
 </script>

--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -57,6 +57,7 @@
         </div>
         <div v-else-if="transactionId" class="rigdig-modal__content">
           <checkout-header
+            :sales-tax="salesTax"
             :truck-info="truckInfo"
             :vin="vin"
             title="Sending Report!"
@@ -103,6 +104,7 @@
         </div>
         <div v-else class="rigdig-modal__content">
           <checkout-header
+            :sales-tax="salesTax"
             :truck-info="truckInfo"
             :vin="vin"
             title="Report found!"
@@ -157,6 +159,28 @@
                     >
                   </template>
                 </label>
+                <label class="rigdig-modal__label">
+                  <template v-if="zip">
+                    <div class="rigdig-widget__label-text">Postal/Zip Code</div>
+                    <input
+                      ref="zip"
+                      :value="zip"
+                      class="form-control rigdig-modal__zip"
+                      type="text"
+                      required
+                    >
+                  </template>
+                  <template v-else>
+                    <div class="rigdig-widget__label-text">Postal/Zip Code</div>
+                    <input
+                      ref="zip"
+                      v-model="userZip"
+                      class="form-control rigdig-modal__zip"
+                      type="text"
+                      required
+                    >
+                  </template>
+                </label>
               </div>
 
               <div class="rigdig-modal__buttons">
@@ -183,7 +207,8 @@
             </form>
             <alert-error v-if="error" :show-help="false" title="Unable to start checkout.">
               <p>
-                The email address you supplied is invalid.  Please verify and try again or
+                The email address or zip code you supplied is invalid.
+                Please verify and try again or
                 <a :href="`mailto:${supportEmail}`">contact us</a>.
               </p>
             </alert-error>
@@ -226,6 +251,10 @@ export default {
       type: String,
       default: null,
     },
+    zip: {
+      type: String,
+      default: null,
+    },
     buttonLabel: {
       type: String,
       default: 'Start checkout',
@@ -263,9 +292,11 @@ export default {
 
   data: () => ({
     userEmail: null,
+    userZip: null,
     error: null,
     loading: false,
     complete: false,
+    salesTax: null,
     transactionToken: null,
     transactionId: null,
     client: null,
@@ -281,6 +312,9 @@ export default {
   created() {
     if (this.email) {
       this.userEmail = this.email;
+    }
+    if (this.zip) {
+      this.userZip = this.zip;
     }
   },
 
@@ -327,6 +361,7 @@ export default {
         body: JSON.stringify({
           vin: this.vin,
           email: this.userEmail,
+          zip: this.userZip,
         }),
       });
       if (!response.ok) {
@@ -341,7 +376,8 @@ export default {
         error.code = response.status;
         throw error;
       }
-      const { Token } = await response.json();
+      const { Token, salesTax } = await response.json();
+      this.salesTax = salesTax;
       return Token;
     },
 

--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -95,6 +95,7 @@
       <checkout-modal
         v-if="verified"
         :email="email"
+        :zip="zip"
         :vin="vin"
         :truck-info="truckInfo"
         :environment="environment"
@@ -130,6 +131,10 @@ export default {
 
   props: {
     email: {
+      type: String,
+      default: null,
+    },
+    zip: {
       type: String,
       default: null,
     },

--- a/packages/rigdig/components/widget.marko
+++ b/packages/rigdig/components/widget.marko
@@ -12,6 +12,7 @@ $ console.log(vin)
   <div class="rigdig-widget">
     <marko-web-browser-component name="RigDigWidget" ssr=true props={
       email: hasUser ? user.email : null,
+      zip: hasUser ? user.postalCode : null,
       inputLabel: input.inputLabel,
       placeholder: '1XPHD48X8CD174…',
       queryVin: vin,


### PR DESCRIPTION
![Screenshot from 2023-11-27 14-25-58](https://github.com/parameter1/randall-reilly-websites/assets/46794001/02ad5033-45e0-46d0-bf68-d350031bbd37)


Ensured the error message fires correctly when an invalid zip is provided alongside adjusting the verbiage to include that the zip code could also be invalid.