### PR TITLE
Fix THR promo images & adjust marko component prop pass through

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -172,6 +172,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                     html: widget.renderToString({
                       title: "Truck History Report",
                       callToAction: "Look up the full history of any truck, including: reported accidents, inspection violations, insurance claim, owner history and more.",
+                      placeholder: "Search by VIN…",
                       checkIdentityX: false,
                       withTag: true,
                       withDesktopImg: true,

--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -17,10 +17,10 @@
         </div>
         <img
           v-if="withMobileImg"
-          class="rigdig-widget__report-img rigdig-widget__report-img--mobile"
-          :src="mobileImgSrc"
-          :srcset="mobileImgSrcSet"
-          alt="Attachments Idea Book Cover"
+          class="lazyload rigdig-widget__report-img rigdig-widget__report-img--mobile"
+          :data-src="mobileImgSrc"
+          :data-srcset="mobileImgSrcSet"
+          alt="Example Report"
         >
       </div>
       <form
@@ -135,9 +135,9 @@
     </div>
     <img
       v-if="withDesktopImg"
-      class="rigdig-widget__report-img rigdig-widget__report-img--desktop"
-      :src="desktopImgSrc"
-      :srcset="desktopImgSrcSet"
+      class="lazyload rigdig-widget__report-img rigdig-widget__report-img--desktop"
+      :data-src="desktopImgSrc"
+      :data-srcset="desktopImgSrcSet"
       alt="Attachments Idea Book Cover"
     >
   </div>
@@ -212,11 +212,11 @@ export default {
     },
     desktopImgSrc: {
       type: String,
-      default: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/thr/inbody-preview.png?h=252',
+      default: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/inbody-preview.svg?h=252',
     },
     desktopImgSrcSet: {
       type: String,
-      default: "['https://img.overdriveonline.com/files/base/randallreilly/all/image/static/thr/inbody-preview.png?h=252&dpr=2 2x']",
+      default: "['https://img.overdriveonline.com/files/base/randallreilly/all/image/static/inbody-preview.svg?h=252&dpr=2 2x']",
     },
     withMobileImg: {
       type: Boolean,
@@ -224,11 +224,11 @@ export default {
     },
     mobileImgSrc: {
       type: String,
-      default: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/rigdigreport-full.png?w=95',
+      default: 'https://img.overdriveonline.com/files/base/randallreilly/all/image/static/rigdigreport-full.svg?w=95',
     },
     mobileImgSrcSet: {
       type: String,
-      default: "['https://img.overdriveonline.com/files/base/randallreilly/all/image/static/rigdigreport-full.png?w=95&dpr=2 2x']",
+      default: "['https://img.overdriveonline.com/files/base/randallreilly/all/image/static/rigdigreport-full.svg?w=95&dpr=2 2x']",
     },
     paymentMethods: {
       type: Array,

--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -71,7 +71,6 @@
             class="learn-more-link"
             :href="learnMoreUrl"
             title="Truck History Report"
-            target="_blank"
           >
             {{ learnMoreText }}
           </a>

--- a/packages/rigdig/components/widget.marko
+++ b/packages/rigdig/components/widget.marko
@@ -8,6 +8,7 @@ $ const { req } = out.global;
 $ const { vin } = getAsObject(req, "query");
 $ const ssr = defaultValue(input.ssr, true);
 $ const checkIdentityX = defaultValue(input.checkIdentityX, true);
+$ const placeholder = defaultValue(input.placeholder, '1XPHD48X8CD174…')
 $ const {
   title,
   callToAction,
@@ -25,7 +26,7 @@ $ const {
       <marko-web-browser-component name="RigDigWidget" ssr=ssr props={
         email: hasUser ? user.email : null,
         inputLabel: input.inputLabel,
-        placeholder: '1XPHD48X8CD174…',
+        placeholder,
         queryVin: vin,
         debug,
         environment,
@@ -47,7 +48,7 @@ $ const {
   <div class="rigdig-widget">
     <marko-web-browser-component name="RigDigWidget" ssr=ssr props={
       inputLabel: input.inputLabel,
-      placeholder: '1XPHD48X8CD174…',
+      placeholder,
       queryVin: vin,
       debug,
       environment,


### PR DESCRIPTION
This will fix the blurry images and correctly utilizes the lazy load and data-src, data-srcset functionality built into the site.  I also update the image calls to SVG, once I figure out how to export them correctly from FIGMA.

This also allow for the pass through of placeholder within the marko component wrapper.  

<img width="618" alt="Screenshot 2023-11-29 at 9 43 22 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/19107c98-c1f8-4ff6-8fcc-b642c10e775a">
<img width="1150" alt="Screenshot 2023-11-29 at 9 43 39 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/9523e8af-bde9-48d6-b966-9bb41d2b7629">
