### PR TITLE
Adjust error displaying within THR in-body widget’s

### DIFF
--- a/packages/global/scss/components/blocks/_thr-vin-lookup-inbody-promo-card.scss
+++ b/packages/global/scss/components/blocks/_thr-vin-lookup-inbody-promo-card.scss
@@ -10,16 +10,24 @@
     background-color: $gray-100;
     border-radius: 4px;
 
+    .rigdig-alert__wrapper {
+      z-index: 5;
+      position: absolute;
+      margin-top: 0;
+      background-color: #f2e4e6; //hsla(0, 100%, 70%, .1)
+      margin-right: 20px;
+    }
+
     @media (max-width: 980px) {
-      &__report-img {
-        display: none;
-      }
       &__header {
        .rigdig-widget__report-img {
           display: block;
           margin-right: 0;
           margin-bottom: 24px;
           align-self: flex-start;
+          &--desktop {
+            display: none;
+          }
         }
       }
     }
@@ -29,9 +37,13 @@
       margin-right: calc(-50vw - -350px);
 
       &__header {
-       .rigdig-widget__report-img {
+       .rigdig-widget__report-img--mobile {
           display: none;
         }
+      }
+
+      &__form {
+        width: 50%;
       }
     }
 
@@ -39,12 +51,12 @@
       display: flex;
       flex-direction: row;
     }
-
+    .rigdig-alert__header,
     &__title {
       margin-bottom: 8px;
       @include skin-typography($style: "header-2");
     }
-
+    .rigdig-alert__wrapper p,
     &__description {
       margin-bottom: 16px;
       @include skin-typography($style: "small-body-text");
@@ -69,10 +81,9 @@
     }
 
     &__report-img {
-      align-self: flex-end;
       margin-left: 24px;
       margin-right: -125px;
-      margin-bottom: -24px;
+      margin-bottom: -149px;
       box-shadow: none;
     }
 

--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -22,6 +22,13 @@
           :data-srcset="mobileImgSrcSet"
           alt="Example Report"
         >
+        <img
+          v-if="withDesktopImg"
+          class="lazyload rigdig-widget__report-img rigdig-widget__report-img--desktop"
+          :data-src="desktopImgSrc"
+          :data-srcset="desktopImgSrcSet"
+          alt="Attachments Idea Book Cover"
+        >
       </div>
       <form
         ref="form"
@@ -132,13 +139,6 @@
         />
       </transition>
     </div>
-    <img
-      v-if="withDesktopImg"
-      class="lazyload rigdig-widget__report-img rigdig-widget__report-img--desktop"
-      :data-src="desktopImgSrc"
-      :data-srcset="desktopImgSrcSet"
-      alt="Attachments Idea Book Cover"
-    >
   </div>
 </template>
 

--- a/sites/overdriveonline.com/server/styles/index.scss
+++ b/sites/overdriveonline.com/server/styles/index.scss
@@ -14,7 +14,11 @@ $skin-newsletter-signup-bg-color: #f0f1f2;
 $skin-newsletter-signup-inline-btn-color: #460c0e;
 
 @import "@randall-reilly/package-global/scss/core";
+/*! critical:start */
+/*! purgecss start ignore */
 @import "@randall-reilly/package-rigdig/scss/rigdig";
+/*! purgecss end ignore */
+/*! critical:end */
 @import "./components/partners-in-business-page";
 
 .site-navbar {

--- a/sites/truckhistoryreport.com/server/styles/index.scss
+++ b/sites/truckhistoryreport.com/server/styles/index.scss
@@ -28,7 +28,9 @@ $skin-newsletter-signup-inline-btn-color: #460c0e;
 
 @import "@randall-reilly/package-global/scss/core";
 /*! critical:start */
+/*! purgecss start ignore */
 @import "@randall-reilly/package-rigdig/scss/rigdig";
+/*! purgecss end ignore */
 /*! critical:end */
 
 .site-navbar {


### PR DESCRIPTION
Update the error display when entering the vin to be absolutely position as to not cause page jumping and render the error relative to the form.  

### Desktop: 
<img width="1226" alt="Screenshot 2023-11-30 at 2 10 22 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/e7da9619-66b0-4352-b791-9f261344f513">


### Mobile: 
<img width="598" alt="Screenshot 2023-11-30 at 2 10 36 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/0a649baf-e0a7-485e-b05c-35fc5a2a3eaa">
