### PR TITLE
Add Partner Insight env config support for merging  standalone block into promo card rotation

### DIFF
--- a/sites/ccjdigital.com/server/templates/index.marko
+++ b/sites/ccjdigital.com/server/templates/index.marko
@@ -39,7 +39,7 @@ $ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO =
     />
   </@section>
 
-  <if(showParnerInsightsAsPromo)>
+  <if(!showParnerInsightsAsPromo)>
     <@section>
       <theme-native-x-card-deck-block
         section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }

--- a/sites/equipmentworld.com/server/components/blocks/marko.json
+++ b/sites/equipmentworld.com/server/components/blocks/marko.json
@@ -1,0 +1,5 @@
+{
+  "<site-promo-card-rotation-block>": {
+    "template": "./promo-card-rotation.marko"
+  }
+}

--- a/sites/equipmentworld.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/equipmentworld.com/server/components/blocks/promo-card-rotation.marko
@@ -1,0 +1,26 @@
+import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
+import PromoA from "@parameter1/base-cms-marko-web-theme-monorail/components/blocks/white-papers";
+import PromoB from "@randall-reilly/package-global/components/blocks/partner-insights-promo";
+
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+$ const cards = (showParnerInsightsAsPromo) ? [
+    {
+      component: PromoA,
+      props: {
+        shuffle: true,
+        limit: 20,
+        'block-title': 'Partner Insights',
+      },
+    },
+    {
+      component: PromoB,
+      props: {},
+    }
+  ] : [
+    {
+      component: PromoA,
+      props: {},
+    }
+  ];
+$ const { component: comp, props } = shuffle(cards)[0];
+<${comp} ...props />

--- a/sites/equipmentworld.com/server/components/marko.json
+++ b/sites/equipmentworld.com/server/components/marko.json
@@ -1,4 +1,7 @@
 {
+  "taglib-imports": [
+    "./blocks/marko.json"
+  ],
   "<eqw-coty-nav>": {
     "template": "./coty-nav.marko"
   }

--- a/sites/equipmentworld.com/server/templates/index.marko
+++ b/sites/equipmentworld.com/server/templates/index.marko
@@ -2,6 +2,8 @@ import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-ali
 
 $ const { id, alias, name, pageNode } = input;
 
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+
 <global-website-section-home-layout
   id=id
   alias=alias
@@ -37,12 +39,14 @@ $ const { id, alias, name, pageNode } = input;
     />
   </@section>
 
-  <@section>
-    <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
-      placement-name="partner-insights"
-    />
-  </@section>
+  <if(!showParnerInsightsAsPromo)>
+    <@section>
+      <theme-native-x-card-deck-block
+        section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
+        placement-name="partner-insights"
+      />
+    </@section>
+  </if>
 
   <@section>
     <theme-section-card-list-block alias="dealers" default-description="What’s impacting today’s dealerships" />
@@ -58,7 +62,7 @@ $ const { id, alias, name, pageNode } = input;
         <global-eqw-coty-promo-block />
       </@slot>
       <@slot>
-        <theme-white-papers-block shuffle=true limit=20 />
+        <site-promo-card-rotation-block />
       </@slot>
     </theme-callout-cards-block>
   </@section>

--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -2,7 +2,9 @@ import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
 import PromoA from "@randall-reilly/package-global/components/blocks/promos/ovd-reader-rigs-submit";
 import PromoB from "@randall-reilly/package-global/components/blocks/ovd-pib-manual-promo";
 import PromoC from "@parameter1/base-cms-marko-web-theme-monorail/components/blocks/white-papers"
-import PromoD from "@randall-reilly/package-global/components/blocks/thr-vin-lookup-promo";
+import PromoD from "@randall-reilly/package-global/components/blocks/partner-insights-promo";
+import PromoF from "@randall-reilly/package-global/components/blocks/thr-vin-lookup-promo";
+
 
 $ const { site } = out.global;
 $ const showInbodyTHRPromo = site.get("showInbodyTHRPromo") || false;
@@ -17,15 +19,11 @@ $ const cards = [
       component: PromoB,
       props: {},
     },
-    {
-      component: PromoC,
-      props: {},
-    },
   ];
 <!-- toggle adding THR promo card based on inbody display of THR promo -->
-$ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) cards.push({ component: PromoD, props: {} });
+$ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) cards.push({ component: PromoF, props: {} });
 <!-- add partner insights promo when configured. -->
-$ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) {
+$ if (showParnerInsightsAsPromo) {
   cards.push({
     component: PromoD,
     props: {
@@ -34,7 +32,13 @@ $ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) {
       'block-title': 'Partner Insights',
     },
   });
+} else {
+  cards.push({
+    component: PromoC,
+    props: {},
+  });
 };
+
 
 $ const { component: comp, props } = shuffle(cards)[0];
 <${comp} ...props />

--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -6,17 +6,35 @@ import PromoD from "@randall-reilly/package-global/components/blocks/thr-vin-loo
 
 $ const { site } = out.global;
 $ const showInbodyTHRPromo = site.get("showInbodyTHRPromo") || false;
-<!-- toggle adding THR promo card based on inbody display of THR promo -->
-$ const cards = (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo)? [
-    PromoA,
-    PromoB,
-    PromoC,
-    PromoD,
-  ] : [
-    PromoA,
-    PromoB,
-    PromoC,
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+
+$ const cards = [
+    {
+      component: PromoA,
+      props: {},
+    },
+    {
+      component: PromoB,
+      props: {},
+    },
+    {
+      component: PromoC,
+      props: {},
+    },
   ];
+<!-- toggle adding THR promo card based on inbody display of THR promo -->
+$ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) cards.push({ component: PromoD, props: {} });
+<!-- add partner insights promo when configured. -->
+$ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) {
+  cards.push({
+    component: PromoD,
+    props: {
+      shuffle: true,
+      limit: 20,
+      'block-title': 'Partner Insights',
+    },
+  });
+};
 
 $ const PromotionComponent = shuffle(cards)[0];
 <${PromotionComponent} />

--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -26,11 +26,7 @@ $ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) cards.push({ component: 
 $ if (showParnerInsightsAsPromo) {
   cards.push({
     component: PromoD,
-    props: {
-      shuffle: true,
-      limit: 20,
-      'block-title': 'Partner Insights',
-    },
+    props: {},
   });
   cards.push({
     component: PromoC,

--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -36,5 +36,5 @@ $ if (process.env.ENABLE_RIGDIG && !showInbodyTHRPromo) {
   });
 };
 
-$ const PromotionComponent = shuffle(cards)[0];
-<${PromotionComponent} />
+$ const { component: comp, props } = shuffle(cards)[0];
+<${comp} ...props />

--- a/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/overdriveonline.com/server/components/blocks/promo-card-rotation.marko
@@ -32,6 +32,15 @@ $ if (showParnerInsightsAsPromo) {
       'block-title': 'Partner Insights',
     },
   });
+  cards.push({
+    component: PromoC,
+    props: {
+      shuffle: true,
+      limit: 20,
+      'block-title': 'Partner Insights',
+    },
+  });
+
 } else {
   cards.push({
     component: PromoC,

--- a/sites/overdriveonline.com/server/templates/index.marko
+++ b/sites/overdriveonline.com/server/templates/index.marko
@@ -4,6 +4,8 @@ $ const { id, alias, name, pageNode } = input;
 $ const { site } = out.global;
 $ const showInbodyTHRPromo = site.get("showInbodyTHRPromo") || false;
 
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+
 <global-website-section-home-layout
   id=id
   alias=alias
@@ -45,12 +47,14 @@ $ const showInbodyTHRPromo = site.get("showInbodyTHRPromo") || false;
     />
   </@section>
 
-  <@section>
-    <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
-      placement-name="partner-insights"
-    />
-  </@section>
+  <if(showParnerInsightsAsPromo)>
+    <@section>
+      <theme-native-x-card-deck-block
+        section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
+        placement-name="partner-insights"
+      />
+    </@section>
+  </if>
 
   <@section>
     <theme-section-card-list-block alias="partners-in-business" />

--- a/sites/overdriveonline.com/server/templates/index.marko
+++ b/sites/overdriveonline.com/server/templates/index.marko
@@ -47,7 +47,7 @@ $ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO =
     />
   </@section>
 
-  <if(showParnerInsightsAsPromo)>
+  <if(!showParnerInsightsAsPromo)>
     <@section>
       <theme-native-x-card-deck-block
         section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }

--- a/sites/totallandscapecare.com/marko.json
+++ b/sites/totallandscapecare.com/marko.json
@@ -1,0 +1,5 @@
+{
+  "taglib-imports": [
+    "./server/components/marko.json"
+  ]
+}

--- a/sites/totallandscapecare.com/server/components/blocks/marko.json
+++ b/sites/totallandscapecare.com/server/components/blocks/marko.json
@@ -1,0 +1,5 @@
+{
+  "<site-promo-card-rotation-block>": {
+    "template": "./promo-card-rotation.marko"
+  }
+}

--- a/sites/totallandscapecare.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/totallandscapecare.com/server/components/blocks/promo-card-rotation.marko
@@ -1,0 +1,26 @@
+import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
+import PromoA from "@parameter1/base-cms-marko-web-theme-monorail/components/blocks/white-papers";
+import PromoB from "@randall-reilly/package-global/components/blocks/partner-insights-promo";
+
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+$ const cards = (showParnerInsightsAsPromo) ? [
+    {
+      component: PromoA,
+      props: {
+        shuffle: true,
+        limit: 20,
+        'block-title': 'Partner Insights',
+      },
+    },
+    {
+      component: PromoB,
+      props: {},
+    }
+  ] : [
+    {
+      component: PromoA,
+      props: {},
+    }
+  ];
+$ const { component: comp, props } = shuffle(cards)[0];
+<${comp} ...props />

--- a/sites/totallandscapecare.com/server/components/marko.json
+++ b/sites/totallandscapecare.com/server/components/marko.json
@@ -1,0 +1,5 @@
+{
+  "taglib-imports": [
+    "./blocks/marko.json"
+  ]
+}

--- a/sites/totallandscapecare.com/server/templates/index.marko
+++ b/sites/totallandscapecare.com/server/templates/index.marko
@@ -2,6 +2,8 @@ import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-ali
 
 $ const { id, alias, name, pageNode } = input;
 
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+
 <global-website-section-home-layout
   id=id
   alias=alias
@@ -37,12 +39,14 @@ $ const { id, alias, name, pageNode } = input;
     />
   </@section>
 
-  <@section>
-    <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
-      placement-name="partner-insights"
-    />
-  </@section>
+  <if(!showParnerInsightsAsPromo)>
+    <@section>
+      <theme-native-x-card-deck-block
+        section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
+        placement-name="partner-insights"
+      />
+    </@section>
+  </if>
 
   <@section>
     <theme-section-card-list-block alias="workforce" default-description="Your people matter" />
@@ -54,7 +58,7 @@ $ const { id, alias, name, pageNode } = input;
         <global-tlc-attachments-idea-promo-block />
       </@slot>
       <@slot>
-        <theme-white-papers-block shuffle=true limit=20 />
+        <site-promo-card-rotation-block />
       </@slot>
     </theme-callout-cards-block>
   </@section>

--- a/sites/truckpartsandservice.com/server/components/blocks/marko.json
+++ b/sites/truckpartsandservice.com/server/components/blocks/marko.json
@@ -1,0 +1,5 @@
+{
+  "<site-promo-card-rotation-block>": {
+    "template": "./promo-card-rotation.marko"
+  }
+}

--- a/sites/truckpartsandservice.com/server/components/blocks/promo-card-rotation.marko
+++ b/sites/truckpartsandservice.com/server/components/blocks/promo-card-rotation.marko
@@ -1,0 +1,26 @@
+import shuffle from "@randall-reilly/package-global/utils/shuffle-array";
+import PromoA from "@parameter1/base-cms-marko-web-theme-monorail/components/blocks/white-papers";
+import PromoB from "@randall-reilly/package-global/components/blocks/partner-insights-promo";
+
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+$ const cards = (showParnerInsightsAsPromo) ? [
+    {
+      component: PromoA,
+      props: {
+        shuffle: true,
+        limit: 20,
+        'block-title': 'Partner Insights',
+      },
+    },
+    {
+      component: PromoB,
+      props: {},
+    }
+  ] : [
+    {
+      component: PromoA,
+      props: {},
+    }
+  ];
+$ const { component: comp, props } = shuffle(cards)[0];
+<${comp} ...props />

--- a/sites/truckpartsandservice.com/server/components/marko.json
+++ b/sites/truckpartsandservice.com/server/components/marko.json
@@ -1,5 +1,6 @@
 {
   "taglib-imports": [
+    "./blocks/marko.json",
     "./directory/marko.json"
   ]
 }

--- a/sites/truckpartsandservice.com/server/templates/index.marko
+++ b/sites/truckpartsandservice.com/server/templates/index.marko
@@ -2,6 +2,8 @@ import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-ali
 
 $ const { id, alias, name, pageNode } = input;
 
+$ const showParnerInsightsAsPromo = process.env.SHOW_PARTNER_INSIGHTS_AS_PROMO === 'true';
+
 <global-website-section-home-layout
   id=id
   alias=alias
@@ -37,12 +39,14 @@ $ const { id, alias, name, pageNode } = input;
     />
   </@section>
 
-  <@section>
-    <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
-      placement-name="partner-insights"
-    />
-  </@section>
+  <if(!showParnerInsightsAsPromo)>
+    <@section>
+      <theme-native-x-card-deck-block
+        section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
+        placement-name="partner-insights"
+      />
+    </@section>
+  </if>
 
   <@section>
     <theme-section-card-list-block alias="distributor-of-the-year-archive" default-description="Keep up to date on the independent aftermarket’s highest honor" />
@@ -54,7 +58,7 @@ $ const { id, alias, name, pageNode } = input;
         <global-tps-used-truck-guide-promo-block />
       </@slot>
       <@slot>
-        <theme-white-papers-block shuffle=true limit=20 />
+        <site-promo-card-rotation-block />
       </@slot>
     </theme-callout-cards-block>
   </@section>


### PR DESCRIPTION
Add the ability to push the Partner Insights call into the promo card rotation based on a env config(SHOW_PARTNER_INSIGHTS_AS_PROMO) set to true.  
Support this:
 - CCJ (no NativeX)
 - EQW
 - OVD ( no nativeX or whitepaper currently running????????)
 - TLC (no NativeX)
 - TPS (no NativeX)
 
 Does not support:
  - CT
  - HWT
  - TN
  - THR
  
  
  
<img width="920" alt="Screenshot 2023-12-04 at 11 34 19 AM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/88e886d7-a3e4-450d-a419-7f3482377a84">
