### PR TITLE
Update source prop  to be widget vs landing page on OVD's in body history report widget. 

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -177,6 +177,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                       withTag: true,
                       withDesktopImg: true,
                       withMobileImg: true,
+                      source: 'widget',
                       learnMoreText: "Learn more about truck history reports",
                       ssr: false,
                       $global,

--- a/packages/rigdig/components/widget.marko
+++ b/packages/rigdig/components/widget.marko
@@ -18,6 +18,7 @@ $ const {
   withMobileImg,
   learnMoreText,
   learnMoreUrl,
+  source,
 } = input;
 
 <if(checkIdentityX)>
@@ -38,6 +39,7 @@ $ const {
         withMobileImg,
         learnMoreText,
         learnMoreUrl,
+        source,
         withDetails,
       } />
     </div>
@@ -60,6 +62,7 @@ $ const {
       withMobileImg,
       learnMoreText,
       learnMoreUrl,
+      source,
       withDetails,
     } />
   </div>


### PR DESCRIPTION

<img width="288" alt="Screenshot 2023-12-05 at 12 50 09 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/3845869/5e8ccec5-fef6-4a0f-bb1a-67cabd0d2b38">
