### PR TITLE
Correct transaction amount truncation and support all postal codes

### DIFF
--- a/packages/payfabric/src/index.js
+++ b/packages/payfabric/src/index.js
@@ -55,7 +55,7 @@ module.exports = (app) => {
       if (!user.postalCode && postalCode) user.postalCode = postalCode;
 
       const salesTax = await calculateSalesTax({ postalCode, pretaxAmount });
-      const amount = pretaxAmount + salesTax;
+      const amount = (pretaxAmount + salesTax).toFixed(2);
       const { Key } = await client.createTransaction({ user, vin, amount });
       const { Token } = await client.createJWT({ transactionId: Key });
       res.json({ Token, salesTax });

--- a/packages/payfabric/src/index.js
+++ b/packages/payfabric/src/index.js
@@ -55,7 +55,7 @@ module.exports = (app) => {
       if (!user.postalCode && postalCode) user.postalCode = postalCode;
 
       const salesTax = await calculateSalesTax({ postalCode, pretaxAmount });
-      const amount = (pretaxAmount + salesTax).toFixed(2);
+      const amount = Number((pretaxAmount + salesTax).toFixed(2));
       const { Key } = await client.createTransaction({ user, vin, amount });
       const { Token } = await client.createJWT({ transactionId: Key });
       res.json({ Token, salesTax });

--- a/packages/payfabric/src/index.js
+++ b/packages/payfabric/src/index.js
@@ -22,6 +22,8 @@ const createError = (message, code) => {
   return error;
 };
 
+const countryCodesRequireZip = new Set(['US', 'CA']);
+
 /**
  * @typedef ResponseContext
  * @prop {import('@parameter1/base-cms-marko-web-identity-x/service')} identityX
@@ -41,10 +43,15 @@ module.exports = (app) => {
   app.post('/__payfabric/create-transaction-token', json(), asyncRoute(async (req, res) => {
     try {
       const { body } = await req;
-      const { vin, email, zip: postalCode } = body;
+      const {
+        vin,
+        countryCode,
+        email,
+        zip: postalCode,
+      } = body;
       if (!vin) throw createError('You must provide a VIN to continue.', 400);
       if (!email) throw createError('You must provide an email address to continue.', 400);
-      if (!postalCode) throw createError('You must provide a zip code to continue', 400);
+      if (!postalCode && countryCodesRequireZip.has(countryCode)) throw createError('You must provide a zip code to continue', 400);
 
       /** @type {ResponseContext} */
       const { identityX } = res.locals;
@@ -53,8 +60,13 @@ module.exports = (app) => {
       const user = ctx.hasUser ? ctx.user : { email };
       // Ensure a postalCode is provided even if existing user record doesn't have one
       if (!user.postalCode && postalCode) user.postalCode = postalCode;
+      // Ensure a countryCode is provided even if existing user record doesn't have one
+      if (!user.countryCode && countryCode) user.countryCode = countryCode;
 
-      const salesTax = await calculateSalesTax({ postalCode, pretaxAmount });
+      const salesTax = countryCodesRequireZip.has(user.countryCode) ? await calculateSalesTax({
+        postalCode,
+        pretaxAmount,
+      }) : 0;
       const amount = Number((pretaxAmount + salesTax).toFixed(2));
       const { Key } = await client.createTransaction({ user, vin, amount });
       const { Token } = await client.createJWT({ transactionId: Key });

--- a/packages/payfabric/src/utils/calculate-sales-tax.js
+++ b/packages/payfabric/src/utils/calculate-sales-tax.js
@@ -14,6 +14,8 @@ module.exports = async ({ postalCode, pretaxAmount }) => {
         {
           quantity: 1,
           amount: pretaxAmount,
+          // https://taxcode.avatax.avalara.com/search?q=DD040000
+          taxCode: 'DD040000',
         },
       ],
       date: `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`,
@@ -27,7 +29,8 @@ module.exports = async ({ postalCode, pretaxAmount }) => {
     }),
   });
   if (!request.ok) throw new Error('Bad fetch response, AvaTax');
-  const { totalTax } = await request.json();
+  const { totalTax, ...rest } = await request.json();
+  console.log(rest);
   // totalTax is the amount of tax applied for this transaction
   return Number(totalTax);
 };

--- a/packages/payfabric/src/utils/calculate-sales-tax.js
+++ b/packages/payfabric/src/utils/calculate-sales-tax.js
@@ -29,8 +29,7 @@ module.exports = async ({ postalCode, pretaxAmount }) => {
     }),
   });
   if (!request.ok) throw new Error('Bad fetch response, AvaTax');
-  const { totalTax, ...rest } = await request.json();
-  console.log(rest);
+  const { totalTax } = await request.json();
   // totalTax is the amount of tax applied for this transaction
   return Number(totalTax);
 };

--- a/packages/payfabric/src/utils/calculate-sales-tax.js
+++ b/packages/payfabric/src/utils/calculate-sales-tax.js
@@ -2,18 +2,32 @@ const fetch = require('node-fetch');
 const { AVATAX_API_HOST, AVATAX_HASHED_CREDENTIALS } = require('../env');
 
 module.exports = async ({ postalCode, pretaxAmount }) => {
-  const request = await fetch(
-    `${AVATAX_API_HOST}/api/v2/taxrates/bypostalcode?country=US&postalCode=${postalCode}`,
-    {
-      method: 'GET',
-      headers: {
-        'content-type': 'application-json',
-        Authorization: `Basic ${AVATAX_HASHED_CREDENTIALS}`,
-      },
+  const now = new Date();
+  const request = await fetch(`${AVATAX_API_HOST}/api/v2/transactions/create`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application-json',
+      Authorization: `Basic ${AVATAX_HASHED_CREDENTIALS}`,
     },
-  );
+    body: JSON.stringify({
+      lines: [
+        {
+          quantity: 1,
+          amount: pretaxAmount,
+        },
+      ],
+      date: `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`,
+      customerCode: 'parameter1-website-customer',
+      addresses: {
+        singleLocation: {
+          postalCode,
+        },
+      },
+      currencyCode: 'USD',
+    }),
+  });
   if (!request.ok) throw new Error('Bad fetch response, AvaTax');
-  const { totalRate } = await request.json();
-  // totalRate is a percent as decimal thus this should give us the dollar amount to add
-  return Number(Math.ceil((totalRate * pretaxAmount) * 100) / 100);
+  const { totalTax } = await request.json();
+  // totalTax is the amount of tax applied for this transaction
+  return Number(totalTax);
 };

--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -161,9 +161,17 @@
                     >
                   </template>
                 </label>
-                <label class="rigdig-modal__label">
+                <country-code
+                  v-model="userCountryCode"
+                  class-name="rigdig-modal__form-group"
+                  :required="true"
+                  label="Country"
+                />
+                <label v-if="zipRequired" class="rigdig-modal__label">
                   <template v-if="zip">
-                    <div class="rigdig-widget__label-text">Postal/Zip Code</div>
+                    <div class="rigdig-widget__label-text">
+                      Postal/Zip Code <strong class="text-danger">*</strong>
+                    </div>
                     <input
                       ref="zip"
                       :value="zip"
@@ -173,7 +181,9 @@
                     >
                   </template>
                   <template v-else>
-                    <div class="rigdig-widget__label-text">Postal/Zip Code</div>
+                    <div class="rigdig-widget__label-text">
+                      Postal/Zip Code <strong class="text-danger">*</strong>
+                    </div>
                     <input
                       ref="zip"
                       v-model="userZip"
@@ -235,6 +245,7 @@
 <script>
 import IconX from '@parameter1/base-cms-marko-web-icons/browser/x.vue';
 import IconCheckCircle from '@parameter1/base-cms-marko-web-icons/browser/check-circle.vue';
+import CountryCode from '@parameter1/base-cms-marko-web-identity-x/browser/form/fields/country.vue';
 import AlertError from './alert-error.vue';
 import CheckoutHeader from './checkout-header.vue';
 
@@ -244,11 +255,16 @@ export default {
   components: {
     AlertError,
     CheckoutHeader,
+    CountryCode,
     IconX,
     IconCheckCircle,
   },
 
   props: {
+    countryCode: {
+      type: String,
+      default: null,
+    },
     email: {
       type: String,
       default: null,
@@ -297,6 +313,7 @@ export default {
   emits: ['cancel', 'purchase', 'error', 'generate'],
 
   data: () => ({
+    userCountryCode: null,
     userEmail: null,
     userZip: null,
     error: null,
@@ -316,6 +333,9 @@ export default {
     total() {
       return (this.salesTax + this.pretaxAmount).toFixed(2);
     },
+    zipRequired() {
+      return new Set(['US', 'CA']).has(this.userCountryCode);
+    },
   },
 
   created() {
@@ -324,6 +344,9 @@ export default {
     }
     if (this.zip) {
       this.userZip = this.zip;
+    }
+    if (this.countryCode) {
+      this.userCountryCode = this.countryCode;
     }
   },
 
@@ -369,6 +392,7 @@ export default {
         headers: { 'content-type': 'application/json; charset=utf-8' },
         body: JSON.stringify({
           vin: this.vin,
+          countryCode: this.userCountryCode,
           email: this.userEmail,
           zip: this.userZip,
         }),

--- a/packages/rigdig/browser/checkout-modal.vue
+++ b/packages/rigdig/browser/checkout-modal.vue
@@ -313,7 +313,7 @@ export default {
   emits: ['cancel', 'purchase', 'error', 'generate'],
 
   data: () => ({
-    userCountryCode: null,
+    userCountryCode: 'US',
     userEmail: null,
     userZip: null,
     error: null,

--- a/packages/rigdig/browser/widget.vue
+++ b/packages/rigdig/browser/widget.vue
@@ -126,6 +126,7 @@
       >
         <checkout-modal
           v-if="verified"
+          :country-code="countryCode"
           :email="email"
           :zip="zip"
           :vin="vin"
@@ -164,6 +165,10 @@ export default {
   inject: ['EventBus'],
 
   props: {
+    countryCode: {
+      type: String,
+      default: null,
+    },
     email: {
       type: String,
       default: null,

--- a/packages/rigdig/components/widget.marko
+++ b/packages/rigdig/components/widget.marko
@@ -26,6 +26,7 @@ $ const {
   <marko-web-identity-x-context|{ hasUser, user }|>
     <div class="rigdig-widget">
       <marko-web-browser-component name="RigDigWidget" ssr=ssr props={
+        countryCode: hasUser ? user.countryCode : null,
         email: hasUser ? user.email : null,
         zip: hasUser ? user.postalCode : null,
         inputLabel: input.inputLabel,
@@ -34,7 +35,7 @@ $ const {
         debug,
         environment,
         paymentMethods,
-        pretaxAmount,                           
+        pretaxAmount,
         title,
         callToAction,
         withTag,

--- a/packages/rigdig/scss/rigdig.scss
+++ b/packages/rigdig/scss/rigdig.scss
@@ -179,6 +179,9 @@ $wrapper-border-radius: 10px !default;
     }
     width: 100%;
   }
+  label[for="sign-on-country"] {
+    font-weight: 600;
+  }
   &__label-text {
     margin-bottom: map-get($spacers, 2);
     font-weight: 600;
@@ -338,6 +341,9 @@ $wrapper-border-radius: 10px !default;
   }
   &__label {
     width: 100%;
+  }
+  label[for="sign-on-country"] {
+    font-weight: 600;
   }
   &__label-text {
     margin-bottom: map-get($spacers, 2);


### PR DESCRIPTION
Previously this was using: https://developer.avalara.com/api-reference/avatax/rest/v2/methods/TaxContent/TaxRatesByPostalCode/ which only supported US postal codes, this now however will use https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateTransaction/ which will support "all" (not all of which have been tested) valid postal codes.

Using `L8G 2V1` (Ontario, Canada):
![Screenshot from 2023-12-29 13-55-05](https://github.com/parameter1/randall-reilly-websites/assets/46794001/3b47a5f2-9acb-42c5-8d74-8286fc2eac85)

Using `53188` (Waukesha, Wisconsin):
![Screenshot from 2023-12-29 13-56-52](https://github.com/parameter1/randall-reilly-websites/assets/46794001/00e6ba32-c8ab-459f-8549-1638fe63ea43)

Using Mexico as the country
![Screenshot from 2024-01-15 12-29-32](https://github.com/parameter1/randall-reilly-websites/assets/46794001/8dcf921d-c153-4b5c-b3a9-7a4af3a5f642)
