### PR TITLE
DOTY Information Page Corrections

### DIFF
--- a/packages/global/components/blocks/sponsors.marko
+++ b/packages/global/components/blocks/sponsors.marko
@@ -4,23 +4,64 @@ $ const { alias, showTitle = true } = input;
 
 $ const sponsorImages = {
   "distributor-of-the-year": [
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/interstate-billing.png", alt: "Distributor Of The Year Award Sponsor: Interstate Billing" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/cvsn.png", alt: "Distributor Of The Year Award Sponsor: CVSN" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/karmak.png", alt: "Distributor Of The Year Award Sponsor: Karmak" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/meritor.png", alt: "Distributor Of The Year Award Sponsor: Meritor" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/HBB_Logo_02_blk.png", alt: "Distributor Of The Year Award Sponsor: High Bar Brands"},
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/Cummins-Meritor.png",
+      alt: "Distributor Of The Year Award Sponsor: Cummins-Meritor",
+      link: { href: "https://www.cummins.com/components/drivetrain-systems", target: "_blank" }
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/CVSN.png",
+      alt: "Distributor Of The Year Award Sponsor: CVSN",
+      link: { href: "https://cvsn.org/", target: "_blank" }
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/High-Bar.png",
+      alt: "Distributor Of The Year Award Sponsor: High Bar Brands",
+      link: { href: "https://www.highbarbrands.com/", target: "_blank" }
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/Interstate-Billing.png",
+      alt: "Distributor Of The Year Award Sponsor: Interstate Billing",
+      link: { href: "https://www.interstatebilling.com/", target: "_blank" }
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/distributor-of-the-year-award/Karmak.png",
+      alt: "Distributor Of The Year Award Sponsor: Karmak",
+      link: { href: "https://karmak.com/", target: "_blank" }
+    },
   ],
   "successful-dealer-award": [
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/interstate-billing.png", alt: "Successful Dealer Award Sponsor: Interstate Billing" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/ntp-horizontal.png", alt: "Successful Dealer Award Sponsor: National Truck Protection" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/karmak.png", alt: "Successful Dealer Award Sponsor: Karmak" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/premium2000.png", alt: "Successful Dealer Award Sponsor: Premium2000+" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/automann.png", alt: "Successful Dealer Award Sponsor: Automann USA"},
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/interstate-billing.png",
+      alt: "Successful Dealer Award Sponsor: Interstate Billing"
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/ntp-horizontal.png",
+      alt: "Successful Dealer Award Sponsor: National Truck Protection"
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/karmak.png",
+      alt: "Successful Dealer Award Sponsor: Karmak"
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/premium2000.png",
+      alt: "Successful Dealer Award Sponsor: Premium2000+"
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/successfull-dealer-award/automann.png",
+      alt: "Successful Dealer Award Sponsor: Automann USA"
+    },
   ],
   "trailblazer-award": [
     { src: "", alt: "" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/hendrickson.png", alt: "Trailblazer Award Sponsor: Hendrickson" },
-    { src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/procede.png", alt: "Trailblazer Award Sponsor: Procede Software" },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/hendrickson.png",
+      alt: "Trailblazer Award Sponsor: Hendrickson"
+    },
+    {
+      src: "https://img.truckpartsandservice.com/files/base/randallreilly/all/image/static/tps/trailblazer-award/procede.png",
+      alt: "Trailblazer Award Sponsor: Procede Software"
+    },
     { src: "", alt: "" },
   ],
 }
@@ -28,7 +69,7 @@ $ const sponsorImages = {
 $ const imgixSponsors = [];
 $ if (sponsorImages[alias]) {
     sponsorImages[alias].forEach((image, index) => {
-    imgixSponsors.push({ src: buildImgixUrl(image.src, { h: 200, auto: 'format,compress' }), alt: image.alt });
+    imgixSponsors.push({ src: buildImgixUrl(image.src, { h: 200, auto: 'format,compress' }), alt: image.alt, link: image.link });
   });
 }
 
@@ -46,12 +87,13 @@ $ if (sponsorImages[alias]) {
   </if>
   <div class="row sponsor-logos">
     <for|image| of=imgixSponsors>
-      $ const { src, alt } = image;
+      $ const { src, alt, link } = image;
       <if(src && alt)>
         <div class="col logo logo__sda">
           <marko-web-img
             class="img-fluid"
             alt=alt
+            link=link
             src=src
             srcset=[`${src}&dpr=2 2x`]
           />

--- a/sites/truckpartsandservice.com/server/templates/static/distributor-of-the-year-award.marko
+++ b/sites/truckpartsandservice.com/server/templates/static/distributor-of-the-year-award.marko
@@ -3,9 +3,10 @@ $ const type = "static";
 $ const getImageSrcFor = (file) => `https://${config.website("imageHost")}/files/base/randallreilly/all/image/static/tps-doty/${file}?w=227`;
 $ const title = "Distributor of the Year Award Nominations";
 $ const content = {
-  name: "Recognizing trucking’s most successful independent distributor operations for their outstanding commitment to business excellence."
+  name: "Recognizing trucking’s most successful distributor operations for their commitment to business excellence."
 }
 $ const description = "Our annual award recognizes trucking’s most successful independent distributor operations for their customer service, industry engagement, corporate leadership and more. Help us celebrate the best of the best with the Distributor of the Year Award.";
+$ const headingStyle = "color: #1A3A54" ;
 <marko-web-default-page-layout type=type title=title description=description>
   <@head>
     <marko-web-gtm-default-context|{ context }| type=type>
@@ -27,31 +28,36 @@ $ const description = "Our annual award recognizes trucking’s most successful 
           alt="Truck, Parts "
           attrs={ style: "width: 100%; margin-bottom: 1.5rem"}
         />
-         <marko-web-content-name tag="h1" block-name=blockName obj=content />
+        <marko-web-content-name
+          tag="h1"
+          block-name=blockName
+          obj=content
+          attrs={ style: headingStyle }
+        />
           <h4><b>Our annual award recognizes trucking’s most successful independent distributor operations for their customer service, industry engagement, corporate leadership and more. Help us celebrate the best of the best with the Distributor of the Year Award.</b></h4>
       </@section>
       <@section>
         <theme-page-contents|{ blockName }|>
           <marko-web-content-body block-name=blockName obj={ body: '__' }>
-            <div class="mt-4" style="background-color: #f0f1f2">
-              <h4 class="text-center">This Year's Sponsors</h4>
+            <div class="mt-4" style="background-color: #f0f1f2; padding:32px">
+              <h4 class="text-center" style="margin-bottom: 0px">This Year's Sponsors</h4>
               <global-sponsors-block alias="distributor-of-the-year" show-title=false />
             </div>
-            <h4 class="mt-4">What is the <em>TPS</em> Distributor of the Year Award?</h4>
-            <p>The <strong>Distributor of the Year</strong> program is one of the aftermarket’s most coveted and highly sought after awards. Now in its 22nd year, the <strong>Distributor of the Year</strong> recognizes independent aftermarket distributors for business performance, business innovation, consistent employee and customer training, market expertise, commitment to customer solutions and more. Businesses named finalists for the <strong>Distributor of the Year</strong> are highlighted on TPS each fall and recognized during an award presentation each January at Heavy Duty Aftermarket Week.</p>
-            <h4>Entry Requirements</h4>
+            <h4 class="mt-4" style=headingStyle>What is the <em>TPS</em> Distributor of the Year Award?</h4>
+            <p>The <strong>Distributor of the Year</strong> program is one of the aftermarket’s most coveted and highly sought after awards. Now in its 22<sup>nd</sup> year, the <strong>Distributor of the Year</strong> recognizes independent aftermarket distributors for business performance, business innovation, consistent employee and customer training, market expertise, commitment to customer solutions and more. Businesses named finalists for the <strong>Distributor of the Year</strong> are highlighted on <em>TPS</em> each fall and recognized during an award presentation each January at Heavy Duty Aftermarket Week.</p>
+            <h4 style=headingStyle>Entry Requirements</h4>
             <p>Any independent aftermarket distributor (except last year’s winner) serving the North American medium- and heavy-duty truck and trailer industries can be nominated for the Distributor of the Year Award. Franchised truck dealers are not eligible (but can participate in the <a href="/successful-dealer-award"><em>Successful Dealer Award</em></a> program).</p>
-            <h4>How Do I Apply?</h4>
-            <p>TPS accepts nominations from anyone involved in the trucking industry for the Distributor of the Year program. Nominations are accepted on our website from April 1 to June 30 each year.</p>
+            <h4 style=headingStyle>How Do I Apply?</h4>
+            <p><em>TPS</em> accepts nominations from anyone involved in the trucking industry for the Distributor of the Year program. Nominations are accepted on our website from April 1 to June 30 each year.</p>
             <p><a href=`/page/2023doy` class="btn btn-primary mt-2 mr-2 mb-2">Apply Now</a></p>
-            <h4>How are finalists and winners selected?</h4>
-            <p>The <strong>Distributor of the Year</strong> program is driven by industry engagement. The five independent distributors who receive the most nominations from the trucking industry each spring are chosen as our annual award finalists. The <strong>Distributor of the Year</strong> winner is chosen through a closed evaluation process conducted by TPS staff.</p>
+            <h4 style=headingStyle>How are finalists and winners selected?</h4>
+            <p>The <strong>Distributor of the Year</strong> program is driven by industry engagement. The five independent distributors who receive the most nominations from the trucking industry each spring are chosen as our annual award finalists. The <strong>Distributor of the Year</strong> winner is chosen through a closed evaluation process conducted by <em>TPS</em> staff.</p>
             <div class="row mb-2" style="border: 5px solid #F0F0F0">
-              <div class="col-lg-3"></div>
-              <div class="col-lg-6 py-2">
+              <div class="col-lg-1"></div>
+              <div class="col-lg-10 py-2">
                 <div class="py-2">
-                  <h4 class="text-center">Prior award winners</h4>
-                  <table class="table table-striped">
+                  <h4 class="text-center" style=headingStyle>Prior award winners</h4>
+                  <table class="table table-striped" style="font-size: 16px">
                     <tr style="background-color: #24408E; color: #FFFFFF;">
                       <th width="30%">
                         <b class="ml-2">YEAR</b>
@@ -142,15 +148,15 @@ $ const description = "Our annual award recognizes trucking’s most successful 
                     </tr>
                     <tr>
                       <td><b>2022</b></td>
-                      <td>Wheldon Parts</td>
+                      <td>Weldon Parts</td>
                     </tr>
                   </table>
                 </div>
               </div>
-              <div class="col-lg-3"></div>
+              <div class="col-lg-1"></div>
             </div>
           </marko-web-content-body>
-          <h4><b>Learn more about our prior Distributor of the Year participants</b></h4>
+          <h4 style=headingStyle><b>Learn more about our prior Distributor of the Year participants</b></h4>
           <theme-section-feed-block alias="distributor-of-the-year-archive" lazyload=false query-name="website-optioned-content">
             <@query-params limit=2 option-name="Pinned" />
           </theme-section-feed-block>


### PR DESCRIPTION
![Screenshot from 2024-01-05 12-55-38](https://github.com/parameter1/randall-reilly-websites/assets/46794001/478c18ab-ffcb-4808-b2c8-02b1f871adfc)
![Screenshot from 2024-01-05 12-55-43](https://github.com/parameter1/randall-reilly-websites/assets/46794001/33290242-643f-4c49-9807-2c835a1032df)
![Screenshot from 2024-01-05 12-55-52](https://github.com/parameter1/randall-reilly-websites/assets/46794001/759621be-0725-42dd-980e-68b6753ae368)

Notable changes include the additional of website links for the sponsors, changing heading colors to the appropriate blue and adjusting the styling of the past winners table.