### PR TITLE
Scooch in Native-X ad when returned

### DIFF
--- a/packages/global/components/content-query-with-injected-native-ads.marko
+++ b/packages/global/components/content-query-with-injected-native-ads.marko
@@ -1,0 +1,59 @@
+import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-node";
+
+$ const injectAds = ({
+    adNodes,
+    contentNodes,
+    place = 'in-place',
+    positions
+  }) => {
+  const positionsReversed = positions.reverse();
+  const nodesWithInjectionSlots = []
+  contentNodes.forEach((contentNode, index) => {
+    const effectiveIndex = index ? (index * 2) + 1 : index;
+    const currentInjectionIndex = positionsReversed[positionsReversed.length - 1];
+    nodesWithInjectionSlots[effectiveIndex] = currentInjectionIndex === index && place === 'before' ? adNodes.pop() || null : null;
+    nodesWithInjectionSlots[effectiveIndex + 1] = currentInjectionIndex === index && place === 'in-place' ? adNodes.pop() || contentNode : contentNode;
+    nodesWithInjectionSlots[effectiveIndex + 2] = currentInjectionIndex === index && place === 'after' ? adNodes.pop() || null : null;
+  });
+  const allNodes = place === 'in-place' ? contentNodes : nodesWithInjectionSlots;
+  return allNodes.filter((node) => node);
+};
+
+$ const allowedQueryNames = [
+  "all-author-content",
+  "all-company-content",
+  "magazine-scheduled-content",
+  "related-published-content",
+  "website-optioned-content",
+  "website-scheduled-content"
+];
+<if(input.queryName && allowedQueryNames.includes(input.queryName))>
+   <marko-web-query|{ nodes: contentNodes }|
+      name=input.queryName
+      params=input.queryParams
+    >
+      $ console.log(contentNodes.length);
+      $ const n = input.positions.length || 0;
+      <marko-web-native-x-fetch-elements|{ ads }| uri=input.uri id=input.placementId opts={ n }>
+        $ const adNodes = ads.filter((ad) => ad.hasCampaign).map((ad) => {
+            const convertedAd = convertAdToContent(ad, { sectionName: input.sectionName }) || {};
+            const { node, attrs: containerAttrs, linkAttrs } = convertedAd;
+            return {
+              ...node,
+              containerAttrs,
+              linkAttrs
+            }
+          });
+        $ const allNodes = injectAds({ adNodes, contentNodes, place: input.place, positions: input.positions });
+        $ const data = { nodes: allNodes };
+      <if(allNodes)>
+        <if(allNodes.length)>
+          <${input.renderBody} ...data />
+        </if>
+        <else>
+          <${input.whenEmpty} />
+        </else>
+      </if>
+      </marko-web-native-x-fetch-elements>
+    </marko-web-query>
+</if>

--- a/packages/global/components/content-query-with-injected-native-ads.marko
+++ b/packages/global/components/content-query-with-injected-native-ads.marko
@@ -6,20 +6,32 @@ $ const injectAds = ({
     place = 'in-place',
     positions
   }) => {
+  const adNodesReversed = adNodes.reverse();
   const positionsReversed = positions.reverse();
   const allNodes = []
   contentNodes.forEach((contentNode, index) => {
-    const effectiveIndex = index ? (index * 2) + 1 : index;
+    const effectiveIndex = (index * 2) + (1 + index);
     const currentInjectionIndex = positionsReversed[positionsReversed.length - 1];
-    console.log(currentInjectionIndex, index, effectiveIndex, effectiveIndex + 1, effectiveIndex + 2, adNodes);
-    allNodes[effectiveIndex] = currentInjectionIndex === index && place === 'before' ? adNodes.pop() || null : null;
-    allNodes[effectiveIndex + 1] = currentInjectionIndex === index && place === 'in-place' ? adNodes.pop() || contentNode : contentNode;
-    allNodes[effectiveIndex + 2] = currentInjectionIndex === index && place === 'after' ? adNodes.pop() || null : null;
-    if (currentInjectionIndex === index) {
+    const currentAdNode = adNodesReversed[adNodesReversed.length - 1];
+    allNodes[effectiveIndex] = null;
+    allNodes[effectiveIndex + 1] = contentNode;
+    allNodes[effectiveIndex + 2] = null;
+    if (currentInjectionIndex === index && place === 'before') {
+      allNodes[effectiveIndex] = currentAdNode;
       positionsReversed.pop();
+      adNodesReversed.pop();
+    }
+    if (currentInjectionIndex === index && place === 'in-place') {
+      allNodes[effectiveIndex + 1] = currentAdNode;
+      positionsReversed.pop();
+      adNodesReversed.pop();
+    }
+    if (currentInjectionIndex === index && place === 'after') {
+      allNodes[effectiveIndex + 2] = currentAdNode;
+      positionsReversed.pop();
+      adNodesReversed.pop();
     }
   });
-  console.log(allNodes);
   return allNodes.filter((node) => node);
 };
 
@@ -32,32 +44,31 @@ $ const allowedQueryNames = [
   "website-scheduled-content"
 ];
 <if(input.queryName && allowedQueryNames.includes(input.queryName))>
-   <marko-web-query|{ nodes: contentNodes }|
-      name=input.queryName
-      params=input.queryParams
-    >
-      $ console.log(contentNodes.length);
-      $ const n = input.positions.length || 0;
-      <marko-web-native-x-fetch-elements|{ ads }| uri=input.uri id=input.placementId opts={ n }>
-        $ const adNodes = ads.filter((ad) => ad.hasCampaign).map((ad) => {
-            const convertedAd = convertAdToContent(ad, { sectionName: input.sectionName }) || {};
-            const { node, attrs: containerAttrs, linkAttrs } = convertedAd;
-            return {
-              ...node,
-              containerAttrs,
-              linkAttrs
-            }
-          });
-        $ const allNodes = injectAds({ adNodes, contentNodes, place: input.place, positions: input.positions });
-        $ const data = { nodes: allNodes };
-      <if(allNodes)>
-        <if(allNodes.length)>
-          <${input.renderBody} ...data />
-        </if>
-        <else>
-          <${input.whenEmpty} />
-        </else>
+  <marko-web-query|{ nodes: contentNodes }|
+    name=input.queryName
+    params=input.queryParams
+  >
+    $ const n = input.positions.length || 0;
+    <marko-web-native-x-fetch-elements|{ ads }| uri=input.uri id=input.placementId opts={ n }>
+      $ const adNodes = ads.filter((ad) => ad.hasCampaign).map((ad) => {
+          const convertedAd = convertAdToContent(ad, { sectionName: input.sectionName }) || {};
+          const { node, attrs: containerAttrs, linkAttrs } = convertedAd;
+          return {
+            ...node,
+            containerAttrs,
+            linkAttrs
+          }
+        });
+      $ const allNodes = injectAds({ adNodes, contentNodes, place: input.place, positions: input.positions });
+      $ const data = { nodes: allNodes };
+    <if(allNodes)>
+      <if(allNodes.length)>
+        <${input.renderBody} ...data />
       </if>
-      </marko-web-native-x-fetch-elements>
-    </marko-web-query>
+      <else>
+        <${input.whenEmpty} />
+      </else>
+    </if>
+    </marko-web-native-x-fetch-elements>
+  </marko-web-query>
 </if>

--- a/packages/global/components/content-query-with-injected-native-ads.marko
+++ b/packages/global/components/content-query-with-injected-native-ads.marko
@@ -7,15 +7,19 @@ $ const injectAds = ({
     positions
   }) => {
   const positionsReversed = positions.reverse();
-  const nodesWithInjectionSlots = []
+  const allNodes = []
   contentNodes.forEach((contentNode, index) => {
     const effectiveIndex = index ? (index * 2) + 1 : index;
     const currentInjectionIndex = positionsReversed[positionsReversed.length - 1];
-    nodesWithInjectionSlots[effectiveIndex] = currentInjectionIndex === index && place === 'before' ? adNodes.pop() || null : null;
-    nodesWithInjectionSlots[effectiveIndex + 1] = currentInjectionIndex === index && place === 'in-place' ? adNodes.pop() || contentNode : contentNode;
-    nodesWithInjectionSlots[effectiveIndex + 2] = currentInjectionIndex === index && place === 'after' ? adNodes.pop() || null : null;
+    console.log(currentInjectionIndex, index, effectiveIndex, effectiveIndex + 1, effectiveIndex + 2, adNodes);
+    allNodes[effectiveIndex] = currentInjectionIndex === index && place === 'before' ? adNodes.pop() || null : null;
+    allNodes[effectiveIndex + 1] = currentInjectionIndex === index && place === 'in-place' ? adNodes.pop() || contentNode : contentNode;
+    allNodes[effectiveIndex + 2] = currentInjectionIndex === index && place === 'after' ? adNodes.pop() || null : null;
+    if (currentInjectionIndex === index) {
+      positionsReversed.pop();
+    }
   });
-  const allNodes = place === 'in-place' ? contentNodes : nodesWithInjectionSlots;
+  console.log(allNodes);
   return allNodes.filter((node) => node);
 };
 

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -79,10 +79,10 @@ $ const perPage = 18;
       }
       placement-id=placementId
       uri=uri
-      positions=[2]
+      positions=[1]
       section-name="Sponsor Content"
-      place="before"
-      >
+      place="after"
+    >
         <marko-web-node-list
           inner-justified=true
           flush-x=true

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -67,31 +67,29 @@ $ const perPage = 18;
       <global-sponsors-block alias=alias.replace("-archive", "") />
     </if>
 
-    <marko-web-query|{ nodes }|
-      name="website-optioned-content"
-      params={
+    $ const { id: placementId, uri } = nxConfig.getPlacement({ name: "native", aliases });
+    <global-content-query-with-injected-native-ads|{ nodes }|
+      query-name="website-optioned-content"
+      query-params={
         limit: 3,
         skip: p.skip({ perPage }),
         sectionAlias: alias,
         optionName: "Pinned",
         queryFragment
       }
-    >
-      $ const newNodes = [...nodes.slice(0,2), null, ...nodes.slice(2)]
-      <marko-web-native-x-retrieve|{ wasFound, hasCampaign, campaign, linkAttrs, containerAttrs }|
-        ...nxConfig.getPlacement({ name: "native", aliases })
-        section-name="Sponsor Content"
+      placement-id=placementId
+      uri=uri
+      positions=[2]
+      section-name="Sponsor Content"
+      place="before"
       >
-        <if(wasFound && hasCampaign)>
-          $ newNodes[2] = { ...campaign, linkAttrs, containerAttrs };
-        </if>
         <marko-web-node-list
           inner-justified=true
           flush-x=true
           flush-y=false
-          modifiers=[]
+          modifiers=["section-feed"]
         >
-          <@nodes nodes=newNodes.filter((v) => v)>
+          <@nodes nodes=nodes>
             <@slot|{ node, index }|>
               <theme-section-feed-content-node
                 display-image=true
@@ -104,8 +102,7 @@ $ const perPage = 18;
             </@slot>
           </@nodes>
         </marko-web-node-list>
-      </marko-web-native-x-retrieve>
-    </marko-web-query>
+    </global-content-query-with-injected-native-ads>
   </@section>
 
   <@section|{ aliases }|>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -1,9 +1,10 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p, GAM } = out.global;
+$ const { pagination: p, GAM, nativeX: nxConfig } = out.global;
 $ const perPage = 18;
 
 <global-website-section-default-layout
@@ -66,10 +67,45 @@ $ const perPage = 18;
       <global-sponsors-block alias=alias.replace("-archive", "") />
     </if>
 
-    <theme-section-feed-block alias=alias lazyload=false query-name="website-optioned-content">
-      <@query-params limit=3 skip=p.skip({ perPage }) option-name="Pinned" />
-      <@native-x name="native" index=2 aliases=aliases section-name="Sponsor Content" />
-    </theme-section-feed-block>
+    <marko-web-query|{ nodes }|
+      name="website-optioned-content"
+      params={
+        limit: 3,
+        skip: p.skip({ perPage }),
+        sectionAlias: alias,
+        optionName: "Pinned",
+        queryFragment
+      }
+    >
+      $ const newNodes = [...nodes.slice(0,2), null, ...nodes.slice(2)]
+      <marko-web-native-x-retrieve|{ wasFound, hasCampaign, campaign, linkAttrs, containerAttrs }|
+        ...nxConfig.getPlacement({ name: "native", aliases })
+        section-name="Sponsor Content"
+      >
+        <if(wasFound && hasCampaign)>
+          $ newNodes[2] = { ...campaign, linkAttrs, containerAttrs };
+        </if>
+        <marko-web-node-list
+          inner-justified=true
+          flush-x=true
+          flush-y=false
+          modifiers=[]
+        >
+          <@nodes nodes=newNodes.filter((v) => v)>
+            <@slot|{ node, index }|>
+              <theme-section-feed-content-node
+                display-image=true
+                with-section=Boolean(node.containerAttrs || node.linkAttrs)
+                lazyload=true
+                node=node
+                container-attrs=node.containerAttrs
+                link-attrs=node.linkAttrs
+              />
+            </@slot>
+          </@nodes>
+        </marko-web-node-list>
+      </marko-web-native-x-retrieve>
+    </marko-web-query>
   </@section>
 
   <@section|{ aliases }|>

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -23,5 +23,8 @@
     },
     "<below-container>": {},
     "<foot>": {}
+  },
+  "<global-content-query-with-injected-native-ads>": {
+    "template": "./content-query-with-injected-native-ads.marko"
   }
 }


### PR DESCRIPTION
RETURNED:
![Screenshot from 2024-04-24 10-57-07](https://github.com/parameter1/randall-reilly-websites/assets/46794001/01a251ce-8078-43c5-a1ae-d46196907186)

NOT RETURNED:
![Screenshot from 2024-04-24 10-57-19](https://github.com/parameter1/randall-reilly-websites/assets/46794001/ef5a39b7-36ff-4d00-bf66-daee3bc63bf8)

This functions as it does on other sites.