### PR TITLE
Remove ‘Welcome’ box on Truck History Report

### DIFF
--- a/sites/truckhistoryreport.com/server/templates/index.marko
+++ b/sites/truckhistoryreport.com/server/templates/index.marko
@@ -16,30 +16,6 @@ $ const { site, config } = out.global;
 <@section>
   <div class="row">
     <div class="col-lg-8">
-      <div class="rigdig__intro rigdig__border-wrapper rigdig__border-wrapper--hom">
-        <div class="">
-          <marko-web-block name="rigdig__logo" modifiers=[] class="">
-            <marko-web-img
-              class="rigdig__graphic"
-              src="https://img.overdriveonline.com/files/base/randallreilly/all/image/static/thr/rigdig-logo.jpg"
-              srcset=["https://img.overdriveonline.com/files/base/randallreilly/all/image/static/thr/rigdig-logo.jpg"]
-              alt="RigDig Logo"
-              attrs={ width: '132px' }
-            />
-          </marko-web-block>
-        </div>
-        <div class="">
-          <h3 class="rigdig__section-title rigdig__section-title--small">
-            Welcome to the new RigDig Truck History Report!
-          </h3>
-          <p>
-            RigDig Truck History Report has a new look and a new home.
-          </p>
-          <p>
-            Looking for <a href="https://rigdigbi.com/" title="RigDig BI" target="_blank">RigDigBI</a>?
-          </p>
-        </div>
-      </div>
       <div class="row rigdig__bg-wrapper">
         <div class="col-lg-12">
           <h3 class="rigdig__section-title">RigDig Truck History Report</h3>


### PR DESCRIPTION
<img width="1531" alt="Screenshot 2024-05-29 at 2 14 31 PM" src="https://github.com/parameter1/randall-reilly-websites/assets/64623209/02952cb1-01c3-4475-be63-05e3858aca64">
