### PR TITLE
Add ‘View More’ link to Partner Insights block on homepage

### DIFF
--- a/sites/ccjdigital.com/server/templates/index.marko
+++ b/sites/ccjdigital.com/server/templates/index.marko
@@ -14,7 +14,7 @@ $ const { id, alias, name, pageNode } = input;
 
   <@section modifiers=["native"]>
     <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers", canonicalPath: "partner-insights" }
+      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers", canonicalPath: "/partner-insights" }
       placement-name="partner-insights"
       limit=4
       view-more=true

--- a/sites/ccjdigital.com/server/templates/index.marko
+++ b/sites/ccjdigital.com/server/templates/index.marko
@@ -14,9 +14,10 @@ $ const { id, alias, name, pageNode } = input;
 
   <@section modifiers=["native"]>
     <theme-native-x-card-deck-block
-      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers" }
+      section={ name: "Partner Insights", description: "Information to advance your business from industry suppliers", canonicalPath: "partner-insights" }
       placement-name="partner-insights"
       limit=4
+      view-more=true
     />
   </@section>
 


### PR DESCRIPTION
<img width="1260" alt="Screenshot 2024-08-21 at 11 01 27 AM" src="https://github.com/user-attachments/assets/10541604-d00e-4e10-b2f1-abad8fa000f8">
