### PR TITLE
Update TN adUnits Ids and set a default TN's NATIVEX_SERVE_URI env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,8 @@ services:
       GAM_TRACK_API_KEY: ${GAM_TRACK_API_KEY-}
       LIVERELOAD_PORT: 19903
       OMEDA_INPUT_ID: ${TN_OMEDA_INPUT_ID-(unset)}
+      NATIVEX_DEFUALT_ID: ${NATIVEX_DEFUALT_ID-}
+      NATIVEX_PI_ID: ${NATIVEX_PI_ID-}
     hostname: www-rr-tn.dev.parameter1.com
     ports:
       - "9903:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,6 @@ services:
       GAM_TRACK_API_KEY: ${GAM_TRACK_API_KEY-}
       LIVERELOAD_PORT: 19903
       OMEDA_INPUT_ID: ${TN_OMEDA_INPUT_ID-(unset)}
-      NATIVEX_SERVE_URI: ${NATIVEX_SERVE_URI-https://delivery.mindfulcms.com/rr-talent/default/compat/native-website}
     hostname: www-rr-tn.dev.parameter1.com
     ports:
       - "9903:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,8 +122,7 @@ services:
       GAM_TRACK_API_KEY: ${GAM_TRACK_API_KEY-}
       LIVERELOAD_PORT: 19903
       OMEDA_INPUT_ID: ${TN_OMEDA_INPUT_ID-(unset)}
-      NATIVEX_DEFUALT_ID: ${NATIVEX_DEFUALT_ID-}
-      NATIVEX_PI_ID: ${NATIVEX_PI_ID-}
+      NATIVEX_SERVE_URI: ${NATIVEX_SERVE_URI-https://delivery.mindfulcms.com/rr-talent/default/compat/native-website}
     hostname: www-rr-tn.dev.parameter1.com
     ports:
       - "9903:80"

--- a/sites/truckersnews.com/config/native-x.js
+++ b/sites/truckersnews.com/config/native-x.js
@@ -8,8 +8,8 @@ config.domainName = 'www.truckersnews.com';
 
 config
   .setAliasPlacements('default', [
-    { name: 'default', id: '6000b7460ea4830001340b96' },
-    { name: 'partner-insights', id: '62c467cc1a8b460001156843' },
+    { name: 'default', id: '670d4b6a22e180b2bbdcfe8b' },
+    { name: 'partner-insights', id: '670d4b7e22e180b2bbdcfe8d' },
   ]);
 
 module.exports = config;

--- a/sites/truckersnews.com/config/native-x.js
+++ b/sites/truckersnews.com/config/native-x.js
@@ -8,8 +8,8 @@ config.domainName = 'www.truckersnews.com';
 
 config
   .setAliasPlacements('default', [
-    { name: 'default', id: process.env.NATIVEX_DEFAULT_ID || '6000b7460ea4830001340b96' },
-    { name: 'partner-insights', id: process.env.NATIVEX_DEFAULT_ID || '62c467cc1a8b460001156843' },
+    { name: 'default', id: '670d4b6a22e180b2bbdcfe8b' },
+    { name: 'partner-insights', id: '670d4b7e22e180b2bbdcfe8d' },
   ]);
 
 module.exports = config;

--- a/sites/truckersnews.com/config/native-x.js
+++ b/sites/truckersnews.com/config/native-x.js
@@ -8,8 +8,8 @@ config.domainName = 'www.truckersnews.com';
 
 config
   .setAliasPlacements('default', [
-    { name: 'default', id: '670d4b6a22e180b2bbdcfe8b' },
-    { name: 'partner-insights', id: '670d4b7e22e180b2bbdcfe8d' },
+    { name: 'default', id: process.env.NATIVEX_DEFAULT_ID || '6000b7460ea4830001340b96' },
+    { name: 'partner-insights', id: process.env.NATIVEX_DEFAULT_ID || '62c467cc1a8b460001156843' },
   ]);
 
 module.exports = config;

--- a/sites/truckersnews.com/config/native-x.js
+++ b/sites/truckersnews.com/config/native-x.js
@@ -1,6 +1,6 @@
 const configureNativeX = require('@randall-reilly/package-global/config/native-x');
 
-const config = configureNativeX();
+const config = configureNativeX({ uri: 'https://delivery.mindfulcms.com/rr-talent/default/compat/native-website' });
 
 config.enabled = true;
 config.publisherId = '5fd267ec1305250001368472';


### PR DESCRIPTION
Set native/mindful unit ids to new TN ones and set a default NATIVEX_SERVE_URI-https://delivery.mindfulcms.com/rr-talent/default/compat/native-website prop

Production version will have to go with the migration: https://github.com/parameter1/randall-reilly-websites/pull/779