### PR TITLE
Adjust deadhead to have a default of 0 as well as allow for 0 as a valid input

### DIFF
--- a/packages/global/browser/load-analyzer.vue
+++ b/packages/global/browser/load-analyzer.vue
@@ -146,7 +146,7 @@
                     v-model="load.deadheadMiles"
                     class="form-control load-analyzer__deadheadMiles"
                     type="number"
-                    min="1"
+                    min="0"
                     step="1"
                     max="2500000"
                     :readonly="loading"
@@ -290,7 +290,7 @@ export default {
     loads: [],
     defaultLoad: {
       quarterDays: null,
-      deadheadMiles: null,
+      deadheadMiles: 0,
       loadedMiles: null,
       grossRate: null,
     },


### PR DESCRIPTION
This will allow for people not to have to enter a value & also set it to 0 as to not effect the formula.

<img width="897" alt="Screenshot 2024-11-21 at 12 47 28 PM" src="https://github.com/user-attachments/assets/15592b2b-663d-4062-b0b5-59dde941538e">
<img width="770" alt="Screenshot 2024-11-21 at 12 47 35 PM" src="https://github.com/user-attachments/assets/c41795ef-1074-4137-be6f-b65707dbd0e7">
