### PR TITLE
Update jobs search box inputs & inline display logic

### DIFF
--- a/packages/global/components/blocks/job-search.marko
+++ b/packages/global/components/blocks/job-search.marko
@@ -1,4 +1,9 @@
 $ const blockName = "careersingear-lookup-banner";
+$ const utm = {
+  source: 'TruckersNews',
+  medium: 'jobs',
+  campaign: 'jobs',
+}
 
 <marko-web-block name=blockName class=input.class>
   <marko-web-element block-name=blockName name="left-col">
@@ -16,7 +21,7 @@ $ const blockName = "careersingear-lookup-banner";
     <marko-web-element block-name=blockName name="description">
       <b>Careersingear.com</b> is the go-to platform for the Trucking industry. Don’t just find the job you need; find the job you want with the company that wants you!
     </marko-web-element>
-    <form action="https://www.careersingear.com/search" method="GET" target="_blank">
+    <form action="https://www.careersingear.com/search?utm_source=TruckersNews&utm_medium=jobs&utm_campaign=search" method="GET" target="_blank">
       <span>
         <div class="form-group">
           <input
@@ -34,6 +39,29 @@ $ const blockName = "careersingear-lookup-banner";
             type="location"
             placeholder="City, State or Zip"
             name="location"
+          />
+        </div>
+        <div class="form-group hidden">
+          <input
+            id="utm_source"
+            class="form-control"
+            type="hidden"
+            value=`${utm.source}`
+            name="utm_source"
+          />
+          <input
+            id="utm_medium"
+            class="form-control"
+            type="hidden"
+            value=`${utm.medium}`
+            name="utm_medium"
+          />
+          <input
+            id="utm_campaign"
+            class="form-control"
+            type="hidden"
+            value=`${utm.campaign}`
+            name="utm_campaign"
           />
         </div>
       </span>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -296,16 +296,15 @@ $ const bypassGate = hasOmedaId(req);
 
             $ const { primarySection } = content;
             <if(displayNewsletterSignup)>
-              <if(primarySection.alias === 'jobs')>
-                <global-job-search-block />
-              </if>
-              <else>
-                <marko-web-identity-x-context|{ hasUser }|>
-                  <if(!hasUser)>
-                    <identity-x-newsletter-form-inline type="inlineContent" />
-                  </if>
-                </marko-web-identity-x-context>
-              </else>
+              <marko-web-identity-x-context|{ hasUser }|>
+                $ const selector = ["a", "b"].sort((a, b) => 0.5 - Math.random())
+                <if(hasUser || (!hasUser && selector[0] === "a"))>
+                  <global-job-search-block />
+                </if>
+                <else-if(!hasUser)>
+                  <identity-x-newsletter-form-inline type="inlineContent" />
+                </else-if>
+              </marko-web-identity-x-context>
             </if>
 
             <if(displaySocialShare)>


### PR DESCRIPTION
Update display logic of when/how jobs box show display
 - Always show when user is present
 - If there is no user randomize display between signup & job search
 - remove restriction on jobs content
