### PR TITLE
Add ability to set gam initOnly on a site level

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -57,7 +57,7 @@ $ const { gamDefer, gtmDefer } = req.query;
       request-frame=true
       target-tag="body"
       on="load"
-      init-only=true
+      init-only=site.get("gam.initOnly", true)
     />
 
     <!-- init native-x -->

--- a/sites/truckersnews.com/config/gam.js
+++ b/sites/truckersnews.com/config/gam.js
@@ -33,4 +33,6 @@ config
     { name: 'wallpaper-right', templateName: 'WALLPAPER', path: 'gear-wallpaper-right' },
   ]);
 
+config.initOnly = false;
+
 module.exports = config;


### PR DESCRIPTION
Set to false on TN only and to true by default

At the moment oneTrust  is being paused within their GTM container.  This is why the initi only true was implemented.  To allow for one trust to set specifics and then trigger the init of ads.  This has been broken with the pausing of the gtm tag.  